### PR TITLE
Introduce offset='packed' option

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="xobjects",
-    version="0.0.6",
+    version="0.0.7",
     description="In-memory serialization and code generator for CPU and GPU",
     author="Riccardo De Maria",
     author_email="riccardo.de.maria@cern.ch",

--- a/xobjects/context.py
+++ b/xobjects/context.py
@@ -205,7 +205,7 @@ class XBuffer(ABC):
     def _make_context(self):
         "return a default context"
 
-    def allocate(self, size, align=False):
+    def allocate(self, size, align=True):
         # find available free slot
         # and update free slot if exists
         if align:

--- a/xobjects/context.py
+++ b/xobjects/context.py
@@ -411,12 +411,11 @@ class Method:
 
 def get_context_from_string(ctxstr):
     import xobjects as xo
-
     if ctxstr is None:
         return xo.ContexCPU()
     else:
         ll = ctxstr.split(":")
-        if len(ll):
+        if len(ll)<=1:
             ctxtype = ll[0]
             option = []
         else:
@@ -445,7 +444,7 @@ def get_test_contexts():
     import os
     import xobjects as xo
 
-    ctxstr = os.environ.get("XOBJECT_TEST_CONTEXTS")
+    ctxstr = os.environ.get("XOBJECTS_TEST_CONTEXTS")
     if ctxstr is None:
         yield xo.ContextCpu()
         yield xo.ContextCpu(omp_num_threads=2)
@@ -469,7 +468,7 @@ def get_test_contexts():
 
 def get_user_context():
     """
-    Get the context specfied by the enviroment variable XOBJECT_USER_CONTEXT.
+    Get the context specfied by the enviroment variable XOBJECTS_USER_CONTEXT.
     If not present use ContextCpu().
 
     Examples:
@@ -482,5 +481,5 @@ def get_user_context():
     """
     import os
 
-    ctxstr = os.environ.get("XOBJECT_USER_CONTEXT")
+    ctxstr = os.environ.get("XOBJECTS_USER_CONTEXT")
     return get_context_from_string(ctxstr)

--- a/xobjects/typeutils.py
+++ b/xobjects/typeutils.py
@@ -16,6 +16,10 @@ def get_a_buffer(size, context=None, buffer=None, offset=None):
         offset = buffer.allocate(size)
     elif offset == "aligned":
         offset = buffer.allocate(size, align=True)
+    elif offset == "packed":
+        offset = buffer.allocate(size, align=False)
+    if isinstance(offset, str):
+        raise ValueError(f'Invalid offset {offset}')
     return buffer, offset
 
 


### PR DESCRIPTION
**New features:**
- When passing ```_offset=packed``` upon creation of a new xobject the default memory alignment is ignored
- Changed default of ```Buffer.allocate(...)``` to ```align=True```

Two bug fixes in alignment logics.