### PR TITLE
Fix dynamic struct copy

### DIFF
--- a/xobjects/struct.py
+++ b/xobjects/struct.py
@@ -231,6 +231,7 @@ class MetaStruct(type):
                             info.extra = extra
                     elif isinstance(arg, cls):
                         info.size = arg._get_size()
+                        info._offsets = {kk: vv for kk, vv in arg._offsets.items()}
                     else:
                         raise ValueError(f"{arg} Not valid type for {cls}")
                 else:  # python argument


### PR DESCRIPTION
Solution for issue #21 

_offset was not copied when making a copy of a dynamic struct. Was causing this behaviour:

```python
import xobjects as xo
class MyStruct(xo.Struct):
    a = xo.Float64
    b = xo.Float64[:]
    c = xo.Float64[:]
s1 = MyStruct(a=2, b=[3,4], c=[5,6])
s2 = MyStruct(s1)
print(s2)
```

gives:
```
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-16-5a04ebac0600> in <module>
----> 1 print(s2)

~/Desktop/20210303_xfields_gpudev/xobjects/xobjects/struct.py in __repr__(self)
    370             for field in self._fields
    371         )
--> 372         fields = ", ".join(f"{k}={v}" for k, v in fields)
    373         longform = f"{self.__class__.__name__}({fields})"
    374         if len(longform) > 60:

~/Desktop/20210303_xfields_gpudev/xobjects/xobjects/struct.py in <genexpr>(.0)
    370             for field in self._fields
    371         )
--> 372         fields = ", ".join(f"{k}={v}" for k, v in fields)
    373         longform = f"{self.__class__.__name__}({fields})"
    374         if len(longform) > 60:

~/Desktop/20210303_xfields_gpudev/xobjects/xobjects/struct.py in <genexpr>(.0)
    367     def __repr__(self):
    368         fields = (
--> 369             (field.name, repr(getattr(self, field.name)))
    370             for field in self._fields
    371         )

~/Desktop/20210303_xfields_gpudev/xobjects/xobjects/struct.py in __get__(self, instance, cls)
     83             return self
     84         else:
---> 85             ftype, offset = self.get_offset(instance)
     86             return ftype._from_buffer(instance._buffer, offset)
     87

~/Desktop/20210303_xfields_gpudev/xobjects/xobjects/struct.py in get_offset(self, instance)
    104     def get_offset(self, instance):  # compatible with info
    105         if self.is_reference:
--> 106             reloffset = instance._offsets[self.index]
    107             if self.is_union:
    108                 absoffset = instance._offset + reloffset

AttributeError: 'MyStruct' object has no attribute '_offsets'
```