### PR TITLE
v0.1.21

### DIFF
--- a/examples/ex_unionref_method.py
+++ b/examples/ex_unionref_method.py
@@ -10,26 +10,26 @@ class Triangle(xo.Struct):
     b = xo.Float64
     h = xo.Float64
 
-    _extra_c_source = """
+    _extra_c_sources = ["""
     /*gpufun*/
     double Triangle_compute_area(Triangle tr, double scale){
         double b = Triangle_get_b(tr);
         double h = Triangle_get_h(tr);
         return 0.5*b*h*scale;
     }
-    """
+    """]
 
 
 class Square(xo.Struct):
     a = xo.Float64
 
-    _extra_c_source = """
+    _extra_c_sources = ["""
     /*gpufun*/
     double Square_compute_area(Square sq, double scale){
         double a = Square_get_a(sq);
         return a*a*scale;
     }
-    """
+    """]
 
 
 class Base(xo.UnionRef):
@@ -48,7 +48,7 @@ class Prism(xo.Struct):
     height = xo.Float64
     volume = xo.Float64
 
-    _extra_c_source = """
+    _extra_c_sources = ["""
     /*gpukern*/
     void Prism_compute_volume(Prism pr){
         Base base = Prism_getp_base(pr);
@@ -56,7 +56,7 @@ class Prism(xo.Struct):
         double base_area = Base_compute_area(base, 3.);
         Prism_set_volume(pr, base_area*height);
     }
-    """
+    """]
 
 
 context = xo.ContextCpu()

--- a/tests/test_capi.py
+++ b/tests/test_capi.py
@@ -246,16 +246,16 @@ def test_dependencies():
 
     class A(xo.Struct):
         a=xo.Float64[:]
-        _extra_c_sources="//blah blah A"
+        _extra_c_sources=["//blah blah A"]
 
     class C(xo.Struct):
         c=xo.Float64[:]
-        _extra_c_sources=" //blah blah C"
+        _extra_c_sources=[" //blah blah C"]
 
     class B(xo.Struct):
         b=A
         c=xo.Float64[:]
-        _extra_c_sources=" //blah blah B"
+        _extra_c_sources=[" //blah blah B"]
         _depends_on=[C]
 
     assert xo.context.sort_classes([B])[1:]==[A,C,B]

--- a/tests/test_capi.py
+++ b/tests/test_capi.py
@@ -246,16 +246,16 @@ def test_dependencies():
 
     class A(xo.Struct):
         a=xo.Float64[:]
-        _extra_c_source="//blah blah A"
+        _extra_c_sources="//blah blah A"
 
     class C(xo.Struct):
         c=xo.Float64[:]
-        _extra_c_source=" //blah blah C"
+        _extra_c_sources=" //blah blah C"
 
     class B(xo.Struct):
         b=A
         c=xo.Float64[:]
-        _extra_c_source=" //blah blah B"
+        _extra_c_sources=" //blah blah B"
         _depends_on=[C]
 
     assert xo.context.sort_classes([B])[1:]==[A,C,B]

--- a/tests/test_ref.py
+++ b/tests/test_ref.py
@@ -194,7 +194,7 @@ def test_unionref():
         b = xo.Float64
         h = xo.Float64
 
-        _extra_c_source = ["""
+        _extra_c_sources = ["""
             /*gpufun*/
             double Triangle_compute_area(Triangle tr, double scale){
                 double b = Triangle_get_b(tr);
@@ -206,7 +206,7 @@ def test_unionref():
     class Square(xo.Struct):
         a = xo.Float64
 
-        _extra_c_source = ["""
+        _extra_c_sources = ["""
             /*gpufun*/
             double Square_compute_area(Square sq, double scale){
                 double a = Square_get_a(sq);
@@ -229,7 +229,7 @@ def test_unionref():
         height = xo.Float64
         volume = xo.Float64
 
-        _extra_c_source = ["""
+        _extra_c_sources = ["""
             /*gpukern*/
             void Prism_compute_volume(Prism pr){
                 Base base = Prism_getp_base(pr);

--- a/tests/test_ref.py
+++ b/tests/test_ref.py
@@ -97,7 +97,7 @@ def test_ref_c_api():
 
         ms2 = MyStruct2(_buffer=ms._buffer, sr=ms, a=[0, 0, 0])
 
-        src = """
+        src = r"""
         /*gpukern*/
         void cp_sra_to_a(MyStruct2 ms, int64_t n){
 
@@ -194,25 +194,25 @@ def test_unionref():
         b = xo.Float64
         h = xo.Float64
 
-        _extra_c_source = """
-        /*gpufun*/
-        double Triangle_compute_area(Triangle tr, double scale){
-            double b = Triangle_get_b(tr);
-            double h = Triangle_get_h(tr);
-            return 0.5*b*h*scale;
-        }
-        """
+        _extra_c_source = ["""
+            /*gpufun*/
+            double Triangle_compute_area(Triangle tr, double scale){
+                double b = Triangle_get_b(tr);
+                double h = Triangle_get_h(tr);
+                return 0.5*b*h*scale;
+            }
+            """]
 
     class Square(xo.Struct):
         a = xo.Float64
 
-        _extra_c_source = """
-        /*gpufun*/
-        double Square_compute_area(Square sq, double scale){
-            double a = Square_get_a(sq);
-            return a*a*scale;
-        }
-        """
+        _extra_c_source = ["""
+            /*gpufun*/
+            double Square_compute_area(Square sq, double scale){
+                double a = Square_get_a(sq);
+                return a*a*scale;
+            }
+            """]
 
     class Base(xo.UnionRef):
         _reftypes = (Triangle, Square)
@@ -229,16 +229,16 @@ def test_unionref():
         height = xo.Float64
         volume = xo.Float64
 
-        _extra_c_source = """
-        /*gpukern*/
-        void Prism_compute_volume(Prism pr){
-            Base base = Prism_getp_base(pr);
-            double height = Prism_get_height(pr);
-            double base_area = Base_compute_area(base, 3.);
-            printf("base_area = %e", base_area);
-            Prism_set_volume(pr, base_area*height);
-        }
-        """
+        _extra_c_source = ["""
+            /*gpukern*/
+            void Prism_compute_volume(Prism pr){
+                Base base = Prism_getp_base(pr);
+                double height = Prism_get_height(pr);
+                double base_area = Base_compute_area(base, 3.);
+                printf("base_area = %e", base_area);
+                Prism_set_volume(pr, base_area*height);
+            }
+            """]
 
     for context in xo.context.get_test_contexts():
         print(f"Test {context}")

--- a/xobjects/__init__.py
+++ b/xobjects/__init__.py
@@ -30,6 +30,6 @@ from .specialize_source import specialize_source
 
 from .typeutils import context_default, get_a_buffer
 
-from .hybrid_class import JEncoder, HybridClass, MetaHybridClass
+from .hybrid_class import JEncoder, HybridClass, MetaHybridClass, ThisClass
 
 from .linkedarray import BypassLinked

--- a/xobjects/context.py
+++ b/xobjects/context.py
@@ -81,8 +81,8 @@ def sources_from_classes(classes):
     sources = []
     for cls in classes:
         sources.append(cls._gen_c_api())
-        if hasattr(cls, "_extra_c_source"):
-            sources.extend(cls._extra_c_source)
+        if hasattr(cls, "_extra_c_sources"):
+            sources.extend(cls._extra_c_sources)
     return sources
 
 

--- a/xobjects/context.py
+++ b/xobjects/context.py
@@ -97,6 +97,9 @@ def _concatenate_sources(sources, apply_to_source=()):
     source = []
     folders = set()
     for ss in sources:
+        if isinstance(ss, Source):
+            ss = ss.source
+
         if hasattr(ss, "read"):
             source.append(ss.read())
             folders.add(os.path.dirname(ss.name))
@@ -415,6 +418,10 @@ class Kernel:
             classes.append(self.ret.atype)
         return classes
 
+class Source:
+    def __init__(self, source, name=None):
+        self.source = source
+        self.name = name
 
 class Method:
     def __init__(self, args, c_name, ret):

--- a/xobjects/context.py
+++ b/xobjects/context.py
@@ -82,7 +82,7 @@ def sources_from_classes(classes):
     for cls in classes:
         sources.append(cls._gen_c_api())
         if hasattr(cls, "_extra_c_source"):
-            sources.append(cls._extra_c_source)
+            sources.extend(cls._extra_c_source)
     return sources
 
 
@@ -93,7 +93,7 @@ def classes_from_kernels(kernels):
     return classes
 
 
-def _concatenate_sources(sources):
+def _concatenate_sources(sources, apply_to_source=()):
     source = []
     folders = set()
     for ss in sources:
@@ -109,6 +109,9 @@ def _concatenate_sources(sources):
     source = "\n".join(source)
 
     folders = [str(ff) for ff in folders]
+
+    for ff in apply_to_source:
+        source = ff(source)
 
     return source, folders
 
@@ -166,6 +169,7 @@ class XContext(ABC):
         sources: list,
         kernels: dict,
         specialize: bool,
+        apply_to_source: list,
         save_source_as: str,
     ):
         pass

--- a/xobjects/context_cpu.py
+++ b/xobjects/context_cpu.py
@@ -121,6 +121,7 @@ class ContextCpu(XContext):
         sources=[],
         kernels=[],
         specialize=True,
+        apply_to_source=(),
         save_source_as=None,
         extra_compile_args=["-O3", "-Wno-unused-function"],
         extra_link_args=["-O3"],
@@ -194,6 +195,8 @@ class ContextCpu(XContext):
         classes = sort_classes(classes)
         cls_sources = sources_from_classes(classes)
 
+        import pdb; pdb.set_trace()
+
         headers = ["#include <stdint.h>"]
 
         if self.omp_num_threads > 0:
@@ -203,7 +206,7 @@ class ContextCpu(XContext):
 
         sources = headers + cls_sources + sources
 
-        source, folders = _concatenate_sources(sources)
+        source, folders = _concatenate_sources(sources, apply_to_source)
 
         if specialize:
             if self.omp_num_threads > 0:

--- a/xobjects/context_cpu.py
+++ b/xobjects/context_cpu.py
@@ -195,8 +195,6 @@ class ContextCpu(XContext):
         classes = sort_classes(classes)
         cls_sources = sources_from_classes(classes)
 
-        import pdb; pdb.set_trace()
-
         headers = ["#include <stdint.h>"]
 
         if self.omp_num_threads > 0:

--- a/xobjects/context_cupy.py
+++ b/xobjects/context_cupy.py
@@ -395,6 +395,7 @@ class ContextCupy(XContext):
         sources=[],
         kernels=[],
         specialize=True,
+        apply_to_source=(),
         save_source_as=None,
         extra_cdef=None,
         extra_classes=[],
@@ -473,7 +474,7 @@ class ContextCupy(XContext):
 
         sources = headers + cls_sources + sources
 
-        source, folders = _concatenate_sources(sources)
+        source, folders = _concatenate_sources(sources, apply_to_source)
         source = "\n".join(['extern "C"{', source, "}"])
 
         if specialize:

--- a/xobjects/context_pyopencl.py
+++ b/xobjects/context_pyopencl.py
@@ -164,6 +164,7 @@ class ContextPyopencl(XContext):
         sources=[],
         kernels=[],
         specialize=True,
+        apply_to_source=(),
         save_source_as=None,
         extra_cdef=None,
         extra_classes=[],
@@ -242,7 +243,7 @@ class ContextPyopencl(XContext):
 
         sources = headers + cls_sources + sources
 
-        source, folders = _concatenate_sources(sources)
+        source, folders = _concatenate_sources(sources, apply_to_source)
 
         if specialize:
             # included files are searched in the same folders od the src_filed

--- a/xobjects/hybrid_class.py
+++ b/xobjects/hybrid_class.py
@@ -146,11 +146,15 @@ class MetaHybridClass(type):
 
 class HybridClass(metaclass=MetaHybridClass):
 
-    def _move_to(self, _context=None, _buffer=None, _offset=None):
+    def move(self, _context=None, _buffer=None, _offset=None):
         self._xobject = self._xobject.__class__(
             self._xobject, _context=_context, _buffer=_buffer, _offset=_offset
         )
         self._reinit_from_xobject(_xobject=self._xobject)
+
+    @property
+    def _move_to(self):
+        raise NameError("`_move_to` has been removed. Use `move` instead.")
 
     def _reinit_from_xobject(self, _xobject):
         self._xobject = _xobject
@@ -251,6 +255,14 @@ class HybridClass(metaclass=MetaHybridClass):
     @property
     def _context(self):
         return self._xobject._buffer.context
+
+    @property
+    def XoStruct(self):
+        raise NameError("`XoStruct` has been removed. Use `_XoStruct` instead.")
+
+    @property
+    def extra_sources(self):
+        raise NameError("`extra_sources` has been removed. Use `_extra_c_sources` instead.")
 
     def compile_kernels(self, *args, **kwargs):
         return self._xobject.compile_kernels(*args, **kwargs)

--- a/xobjects/hybrid_class.py
+++ b/xobjects/hybrid_class.py
@@ -3,7 +3,9 @@
 # Copyright (c) CERN, 2021.                   #
 # ########################################### #
 
+from hashlib import new
 import json
+from inspect import isclass
 
 import numpy as np
 from .struct import Struct
@@ -71,7 +73,7 @@ def _build_xofields_dict(bases, data):
         xofields = {}
 
     for nn, tt in xofields.items():
-        if hasattr(tt, '_XoStruct'):
+        if isclass(tt) and issubclass(tt, HybridClass):
             xofields[nn] = tt._XoStruct
 
     return xofields
@@ -131,7 +133,13 @@ class MetaHybridClass(type):
                 for aa in kk.args:
                     if aa.atype is ThisClass:
                         aa.atype = new_class._XoStruct
+                    if isclass(aa.atype) and issubclass(aa.atype, HybridClass):
+                        aa.atype = aa.atype._XoStruct
             new_class._XoStruct._kernels.update(kernels)
+
+        for ii, tt in enumerate(new_class._XoStruct._depends_on):
+            if isclass(tt) and issubclass(tt, HybridClass):
+                new_class._XoStruct._depends_on[ii] = tt._XoStruct
 
         return new_class
 

--- a/xobjects/hybrid_class.py
+++ b/xobjects/hybrid_class.py
@@ -70,6 +70,10 @@ def _build_xofields_dict(bases, data):
     else:
         xofields = {}
 
+    for nn, tt in xofields.items():
+        if hasattr(tt, '_XoStruct'):
+            xofields[nn] = tt._XoStruct
+
     return xofields
 
 

--- a/xobjects/hybrid_class.py
+++ b/xobjects/hybrid_class.py
@@ -115,8 +115,8 @@ class MetaHybridClass(type):
 
         XoStruct._DressingClass = new_class
 
-        if '_extra_c_source' in data.keys():
-            new_class.XoStruct._extra_c_source.extend(data['_extra_c_source'])
+        if '_extra_c_sources' in data.keys():
+            new_class.XoStruct._extra_c_sources.extend(data['_extra_c_sources'])
 
         if '_depends_on' in data.keys():
             new_class.XoStruct._depends_on.extend(data['_depends_on'])

--- a/xobjects/hybrid_class.py
+++ b/xobjects/hybrid_class.py
@@ -116,9 +116,8 @@ class MetaHybridClass(type):
 
         XoStruct._DressingClass = new_class
 
-        XoStruct.extra_sources = []
-        if 'extra_sources' in data.keys():
-            new_class.XoStruct.extra_sources.extend(data['extra_sources'])
+        if '_extra_c_source' in data.keys():
+            new_class.XoStruct._extra_c_source.extend(data['_extra_c_source'])
 
         return new_class
 
@@ -233,7 +232,7 @@ class HybridClass(metaclass=MetaHybridClass):
                 return
 
         context.add_kernels(
-            sources=self.XoStruct.extra_sources,
+            sources=[],
             kernels=self.XoStruct.custom_kernels,
             extra_classes=[self.XoStruct],
             save_source_as=save_source_as,

--- a/xobjects/struct.py
+++ b/xobjects/struct.py
@@ -59,7 +59,7 @@ from .typeutils import (
 
 from .scalar import Int64
 from .array import Array
-
+from .context import Source
 
 log = logging.getLogger(__name__)
 
@@ -417,7 +417,10 @@ class Struct(metaclass=MetaStruct):
         from . import capi
 
         paths = cls._gen_data_paths()
-        return capi.gen_code(cls, paths, conf)
+
+        source = Source(source=capi.gen_code(cls, paths, conf),
+                        name=cls.__name__+'_gen_c_api')
+        return source
 
     @classmethod
     def _gen_c_decl(cls, conf=default_conf):

--- a/xobjects/struct.py
+++ b/xobjects/struct.py
@@ -258,8 +258,8 @@ class MetaStruct(type):
                 _has_refs = True
                 break
         data['_has_refs'] = _has_refs
-        if '_extra_c_source' not in data.keys():
-            data['_extra_c_source'] = []
+        if '_extra_c_sources' not in data.keys():
+            data['_extra_c_sources'] = []
         if '_depends_on' not in data.keys():
             data['_depends_on'] = []
         if '_kernels' not in data.keys():

--- a/xobjects/struct.py
+++ b/xobjects/struct.py
@@ -258,6 +258,8 @@ class MetaStruct(type):
                 _has_refs = True
                 break
         data['_has_refs'] = _has_refs
+        if '_extra_c_source' not in data.keys():
+            data['_extra_c_source'] = []
 
         return type.__new__(cls, name, bases, data)
 


### PR DESCRIPTION
**Changes**

Improved and reorganised management of sources and dependencies:
 - Replaced ```extra_sources``` and ```_extra_c_source``` with ```_extra_c_sources``` both in ```xobjects.Struct``` and in ```xobjects.HybridClass```. 
 - Kernel declarations can be made through the ```_kernels``` dictionary when creating subclasses of ```xobjects.Struct``` and in ```xobjects.HybridClass```. The kernels can be compiled by the ```compile_kernels(...)``` method.
 - Dependencies on additional xobjects types can be provided through the ```_depends_on``` list when creating subclasses of ```xobjects.Struct``` and in ```xobjects.HybridClass```. These are taken into account when compiling the kernels.
 - ```Context.add_kernels``` can apply a user-provided list of functions to the source code before code specialization.
 - Renamed ```HybridClass.XoStruct``` to ```HybridClass._XoStruct```
 - Renamed ```HybridClass._move_to``` to ```HybridClass.move```