### PR TITLE
get_a_buffer: forbid specifying a mismatched buffer+context, offset cannot be a number

### DIFF
--- a/tests/test_typeutils.py
+++ b/tests/test_typeutils.py
@@ -1,0 +1,99 @@
+# copyright ################################# #
+# This file is part of the Xobjects Package.  #
+# Copyright (c) CERN, 2021.                   #
+# ########################################### #
+
+import xobjects as xo
+
+import pytest
+
+
+def test_get_a_buffer_ctx_none_buff_none_offset_none():
+    buffer, offset = xo.get_a_buffer(size=16)
+    assert buffer.context.__class__ == xo.context_default.__class__
+    assert offset == 0
+    assert buffer.capacity == 16
+
+
+def test_get_a_buffer_ctx_none_buff_none_offset_given():
+    with pytest.raises(ValueError):
+        _ = xo.get_a_buffer(size=16, offset=5)
+
+
+def test_get_a_buffer_ctx_none_buff_given_offset_none():
+    original_buffer = xo.context_default.new_buffer(16)
+    buffer, offset = xo.get_a_buffer(size=16, buffer=original_buffer)
+    assert buffer is original_buffer
+    assert buffer.capacity >= 16
+
+
+def test_get_a_buffer_ctx_none_buff_given_offset_given():
+    original_buffer = xo.context_default.new_buffer(16)
+    with pytest.raises(ValueError):
+        _ = xo.get_a_buffer(size=16, buffer=original_buffer, offset=3)
+
+
+def test_get_a_buffer_ctx_given_buff_none_offset_none():
+    context = xo.ContextCpu()
+    buffer, offset = xo.get_a_buffer(size=32, context=context)
+    assert buffer.context is context
+    assert offset == 0
+    assert buffer.capacity >= 32
+
+
+def test_get_a_buffer_ctx_given_buff_none_offset_given():
+    with pytest.raises(ValueError):
+        _ = xo.get_a_buffer(size=16, offset=5)
+
+
+def test_get_a_buffer_ctx_given_buff_given_offset_none_ok():
+    context = xo.ContextCpu()
+    original_buffer = context.new_buffer(16)
+    buffer, offset = xo.get_a_buffer(
+        size=32, context=context, buffer=original_buffer
+    )
+    assert buffer is original_buffer
+    assert buffer.context is context
+    assert offset == 0
+    assert buffer.capacity >= 32
+
+
+def test_get_a_buffer_ctx_given_buff_given_offset_none_fail():
+    context1, context2 = xo.ContextCpu(), xo.ContextCpu()
+    assert context1 is not context2
+
+    buffer_on_context1 = context1.new_buffer(16)
+
+    with pytest.raises(ValueError):
+        _ = xo.get_a_buffer(
+            size=16,
+            context=context2,
+            buffer=buffer_on_context1,
+        )
+
+
+@pytest.mark.parametrize('input_offset', ['packed', 'aligned'])
+def test_get_a_buffer_ctx_given_buff_given_offset_given_ok(input_offset):
+    context = xo.ContextCpu()
+    original_buffer = context.new_buffer(16)
+    buffer, offset = xo.get_a_buffer(
+        size=32,
+        context=context,
+        buffer=original_buffer,
+        offset=input_offset,
+    )
+    assert buffer is original_buffer
+    assert buffer.context is context
+    assert buffer.capacity >= 32
+
+
+def test_get_a_buffer_ctx_given_buff_given_offset_given_fail():
+    context = xo.ContextCpu()
+    original_buffer = context.new_buffer(16)
+    with pytest.raises(ValueError):
+        buffer, offset = xo.get_a_buffer(
+            size=32,
+            context=context,
+            buffer=original_buffer,
+            offset=1234,
+        )

--- a/xobjects/typeutils.py
+++ b/xobjects/typeutils.py
@@ -17,14 +17,20 @@ def get_a_buffer(size, context=None, buffer=None, offset=None):
         if context is None:
             context = context_default
         buffer = context.new_buffer(size)
+    elif buffer.context is not context and context is not None:
+        raise ValueError(
+            f"Mismatched buffer ({buffer}) and context ({context})")
+
     if offset is None:
         offset = buffer.allocate(size)
     elif offset == "aligned":
         offset = buffer.allocate(size, align=True)
     elif offset == "packed":
         offset = buffer.allocate(size, align=False)
-    if isinstance(offset, str):
-        raise ValueError(f"Invalid offset {offset}")
+    else:
+        raise ValueError(
+            f"Value of `offset` can only be 'packed', 'aligned', or None"
+        )
     return buffer, offset
 
 


### PR DESCRIPTION
- To align with the newly updated guide, this throws an error when the explicitly passed buffer is not on the explicitly passed context.
- Following the discussion with @rdemaria, I prohibit passing anything different to `None`, `'packed'`, or `'aligned'` as `offset`. This gets rid of the strange behaviour where:

```python
buffer = xo.get_a_buffer(size=BIGGER, buffer=xo.context_default.new_buffer(SMALLER), offset=OFFSET)
buffer.capacity  # => SMALLER if OFFSET is an integer, otherwise BIGGER
```

- Added a bunch of tests asserting the described behaviour of `get_a_buffer`

CPU tests pass https://github.com/szymonlopaciuk/xsuite/actions/runs/3136410559