### PR TITLE
[wip] add a missing semicolon in `capi.Index_get_c_offset`

### DIFF
--- a/tests/test_array.py
+++ b/tests/test_array.py
@@ -15,12 +15,12 @@ from xobjects.typeutils import Info
 def test_get_shape():
     from xobjects.array import get_shape_from_array
 
-    assert get_shape_from_array(0) == ()
-    assert get_shape_from_array([]) == (0,)
-    assert get_shape_from_array([1, 2, 3]) == (3,)
-    assert get_shape_from_array(range(3)) == (3,)
-    assert get_shape_from_array([[], []]) == (2, 0)
-    assert get_shape_from_array([[2], [2]]) == (2, 1)
+    assert get_shape_from_array(0,0) == ()
+    assert get_shape_from_array([],1) == (0,)
+    assert get_shape_from_array([1, 2, 3],1) == (3,)
+    assert get_shape_from_array(range(3),1) == (3,)
+    assert get_shape_from_array([[], []],2) == (2, 0)
+    assert get_shape_from_array([[2], [2]],2) == (2, 1)
 
 
 def mk_classes() -> xo.Array:
@@ -185,6 +185,13 @@ def test_array_dshape_dtype():
     ss1 = Array1(3)
     ss2 = Array1(4)
     assert ss0._shape == ss[0]._shape
+
+
+    ss = Array2([[1], [2,3], [4,5,6]])
+    assert ss[0][0]==1
+    assert ss[1][1]==3
+    assert ss[2][2]==6
+
 
 
 def test_array_in_struct():

--- a/tests/test_capi.py
+++ b/tests/test_capi.py
@@ -258,6 +258,49 @@ def test_dependencies():
         _extra_c_sources=[" //blah blah B"]
         _depends_on=[C]
 
-    assert xo.context.sort_classes([B])[1:]==[A,C,B]
+    assert xo.context.sort_classes([B])[1:] == [A, C, B]
 
 
+def test_dynarray_getp1():
+    ArrNUInt8 = xo.UInt8[:]
+    char_array = ArrNUInt8([42, 43, 44])
+
+    kernels = ArrNUInt8._gen_kernels()
+    ctx = xo.ContextCpu()
+    ctx.add_kernels(kernels=kernels, save_source_as='test-u8.c')
+
+    assert ctx.kernels.ArrNUInt8_len(obj=char_array) == 3
+
+    s1 = ctx.kernels.ArrNUInt8_getp1(obj=char_array, i0=0)
+    s2 = ctx.kernels.ArrNUInt8_getp1(obj=char_array, i0=1)
+    s3 = ctx.kernels.ArrNUInt8_getp1(obj=char_array, i0=2)
+
+    import ipdb; ipdb.set_trace()
+
+    assert ffi.cast("char *", s1)[0] == 42
+    assert ffi.cast("char *", s2)[0] == 43
+    assert ffi.cast("char *", s3)[1] == 44
+
+
+def test_array_string():
+    ArrNString = xo.String[:]
+    string_array = ArrNString(['a', 'bc', 'def'])
+
+    kernels = ArrNString._gen_kernels()
+    ctx = xo.ContextCpu()
+    ctx.add_kernels(kernels=kernels, save_source_as='test.c')
+
+    assert ctx.kernels.ArrNString_len(obj=string_array) == 3
+
+    s1 = ctx.kernels.ArrNString_getp1(obj=string_array, i0=0)
+    s2 = ctx.kernels.ArrNString_getp1(obj=string_array, i0=1)
+    s3 = ctx.kernels.ArrNString_getp1(obj=string_array, i0=2)
+
+    # import ipdb; ipdb.set_trace()
+
+    assert ffi.cast("char *", s1)[0] == 0x61
+    assert ffi.cast("char *", s2)[0] == 0x62
+    assert ffi.cast("char *", s2)[1] == 0x63
+    assert ffi.cast("char *", s3)[0] == 0x64
+    assert ffi.cast("char *", s3)[1] == 0x65
+    assert ffi.cast("char *", s3)[2] == 0x66

--- a/xobjects/capi.py
+++ b/xobjects/capi.py
@@ -143,6 +143,7 @@ def Index_get_c_offset(part, conf, icount):
     if cls._is_static_type:
         out.append(f"  offset+={soffset};")
     else:
+        #import ipdb; ipdb.set_trace()
         out.append(int_from_obj(f"offset+{soffset}", conf) + ";")
     return out
 

--- a/xobjects/capi.py
+++ b/xobjects/capi.py
@@ -143,7 +143,7 @@ def Index_get_c_offset(part, conf, icount):
     if cls._is_static_type:
         out.append(f"  offset+={soffset};")
     else:
-        out.append(int_from_obj(f"offset+{soffset}", conf))
+        out.append(int_from_obj(f"offset+{soffset}", conf) + ";")
     return out
 
 


### PR DESCRIPTION
There is a missing semicolon in `capi` that can occasionally lead to a build failure.