### PR TITLE
fix bugs in capi

### DIFF
--- a/tests/test_capi.py
+++ b/tests/test_capi.py
@@ -5,18 +5,158 @@
 
 # pylint:disable=E1101
 
+import pytest
+import math
 import numpy as np
-import xobjects as xo
 import cffi
+
+import xobjects as xo
+
 
 ffi = cffi.FFI()
 
 
-def test_struct1():
-    class Struct1(xo.Struct):
-        field1 = xo.Int64
-        field2 = xo.Float64
+class Struct1(xo.Struct):
+    field1 = xo.Int64
+    field2 = xo.Float64
 
+
+class Struct2(xo.Struct):
+    field1 = xo.Int32
+    field2 = xo.Float64[:]
+
+
+class Struct2r(xo.Struct):
+    field1 = xo.Int32
+    field2 = xo.Ref[xo.Float64[:]]
+
+
+class Struct3(xo.Struct):
+    field1 = xo.Float64
+    field2 = xo.Float32[:]
+    field3 = xo.Float64[:]
+    field4 = xo.String
+
+
+class Struct3r(xo.Struct):
+    field1 = xo.Float64
+    field2 = xo.Ref[xo.Float32[:]]
+    field3 = xo.Ref[xo.Float64[:]]
+
+
+class Struct4(xo.Struct):
+    field1 = xo.Float64
+    field2 = xo.Float32[:]
+    field3 = xo.Float64[:]
+    field4 = xo.Int8[:]
+
+
+class Struct5(xo.Struct):
+    field1 = Struct1
+    field2 = Struct2
+    field2r = Struct2r
+    field3 = Struct3
+    field3r = Struct3r
+    field4 = Struct4
+
+
+class DynLenType(xo.Struct):
+    field1 = xo.Int32[:]
+
+
+class URef(xo.UnionRef):
+    _reftypes = [Struct1, Struct2]
+
+
+@pytest.mark.parametrize(
+    'array_cls, example_shape',
+    [
+        (xo.Int64[2], (2,)),
+        (xo.Int64[:], (2,)),
+        (xo.Int8[3], (3,)),
+        (xo.Int8[:], (3,)),
+        (xo.Int32[4, 5], (4, 5)),
+        (xo.Int32[4, :], (4, 5)),
+        (xo.Int32[:, 5], (4, 5)),
+        (xo.Int64[2, 3, 5], (2, 3, 5)),
+        (xo.Int64[:, 3, :], (2, 3, 5)),
+        (xo.Int64[5, :, 2], (5, 13, 2)),
+    ]
+)
+def test_array_static_type_init_get_set(array_cls, example_shape):
+    c_name = array_cls.__name__
+    length = math.prod(example_shape)
+
+    kernels = array_cls._gen_kernels()
+    ctx = xo.ContextCpu()
+    ctx.add_kernels(kernels=kernels)
+
+    ini = np.arange(length).reshape(example_shape) + 7  # let's not have zeros
+
+    a2 = array_cls(ini)
+
+    len_fun = getattr(ctx.kernels, f'{c_name}_len')
+    get_fun = getattr(ctx.kernels, f'{c_name}_get')
+    set_fun = getattr(ctx.kernels, f'{c_name}_set')
+
+    assert len_fun(obj=a2) == length
+    for ii, vv in np.ndenumerate(ini):
+        idx_kwargs = {f'i{dim}': jj for dim, jj in enumerate(ii)}
+
+        a2[ii] = vv * 3
+        assert get_fun(obj=a2, **idx_kwargs) == vv * 3
+
+        set_fun(obj=a2, value=vv * 4, **idx_kwargs)
+        assert a2[ii] == vv * 4
+
+
+@pytest.mark.parametrize(
+    'array_cls, example_shape',
+    [
+        (DynLenType[3], (3,)),
+        (DynLenType[:], (3,)),
+        (DynLenType[3, 4], (3, 4)),
+        (DynLenType[:, 4], (3, 4)),
+        (DynLenType[:, :], (3, 4)),
+        (DynLenType[2, 3, 4], (2, 3, 4)),
+        (DynLenType[2, :, 4], (2, 3, 4)),
+        (DynLenType[:, 3, :], (2, 3, 4)),
+    ]
+)
+def test_array_dynamic_type_init_get_set(array_cls, example_shape):
+    c_name = array_cls.__name__
+    length = math.prod(example_shape)
+
+    kernels = array_cls._gen_kernels()
+    ctx = xo.ContextCpu()
+    ctx.add_kernels(kernels=kernels, save_source_as=f'{c_name}.c')
+
+    numbers = [np.arange(ii) + ii + 3 for ii in range(length)]
+    dt_fields = [DynLenType(field1=nums) for nums in numbers]
+
+    numbers = np.array(numbers, dtype=object).reshape(example_shape)
+    dt_fields = np.array(dt_fields).reshape(example_shape)
+
+    arr = array_cls(dt_fields)
+
+    len_fun = getattr(ctx.kernels, f'{c_name}_len')
+    len_fun_f = getattr(ctx.kernels, f'{c_name}_len{len(example_shape)}_field1')
+    get_fun_f = getattr(ctx.kernels, f'{c_name}_get_field1')
+    set_fun_f = getattr(ctx.kernels, f'{c_name}_set_field1')
+
+    assert len_fun(obj=arr) == len(arr)
+
+    for ii, field in np.ndenumerate(numbers):
+        idx_kwargs = {f'i{dim}': jj for dim, jj in enumerate(ii)}
+        assert len_fun_f(obj=arr, **idx_kwargs) == len(field)
+        for idx_in_field, vv in enumerate(field):
+            idx_kwargs[f'i{len(ii)}'] = idx_in_field
+            assert get_fun_f(obj=arr, **idx_kwargs) == vv
+            set_fun_f(obj=arr, value=13*vv, **idx_kwargs)
+            assert arr[ii].field1[idx_in_field] == 13 * vv
+
+
+def test_struct1():
     kernels = Struct1._gen_kernels()
     ctx = xo.ContextCpu()
     ctx.add_kernels(kernels=kernels)
@@ -24,10 +164,10 @@ def test_struct1():
     s1 = Struct1(field1=2, field2=3.0)
 
     ctx.kernels.Struct1_set_field1(obj=s1, value=7)
-    ctx.kernels.Struct1_get_field1(obj=s1) == s1.field1
+    assert ctx.kernels.Struct1_get_field1(obj=s1) == s1.field1
 
     ctx.kernels.Struct1_set_field2(obj=s1, value=7)
-    ctx.kernels.Struct1_get_field2(obj=s1) == s1.field2
+    assert ctx.kernels.Struct1_get_field2(obj=s1) == s1.field2
 
     ps = ctx.kernels.Struct1_getp(obj=s1)
     p1 = ctx.kernels.Struct1_getp_field1(obj=s1)
@@ -39,82 +179,210 @@ def test_struct1():
     assert p2[0] == s1.field2
 
 
-def test_array1():
-    Array1 = xo.Int64[2]
-
-    kernels = Array1._gen_kernels()
-    ctx = xo.ContextCpu()
-    ctx.add_kernels(kernels=kernels)
-
-    ini = [2, 7]
-
-    a1 = Array1(ini)
-
-    assert ctx.kernels.Arr2Int64_len(obj=a1) == len(ini)
-    for ii, vv in enumerate(ini):
-        a1[ii] = ii * 3
-        assert ctx.kernels.Arr2Int64_get(obj=a1, i0=ii) == ii * 3
-        ctx.kernels.Arr2Int64_set(obj=a1, i0=ii, value=ii * 4)
-        assert a1[ii] == ii * 4
-
-
-def test_array2():
-    Array2 = xo.Int64[:]
-
-    kernels = Array2._gen_kernels()
-    ctx = xo.ContextCpu()
-    ctx.add_kernels(kernels=kernels)
-
-    ini = [2, 7, 3]
-
-    a1 = Array2(ini)
-
-    assert ctx.kernels.ArrNInt64_len(obj=a1) == len(ini)
-    for ii, vv in enumerate(ini):
-        a1[ii] = ii * 3
-        assert ctx.kernels.ArrNInt64_get(obj=a1, i0=ii) == ii * 3
-        ctx.kernels.ArrNInt64_set(obj=a1, i0=ii, value=ii * 4)
-        assert a1[ii] == ii * 4
-
-
 def test_struct2():
-    class Struct2(xo.Struct):
-        field1 = xo.Int32
-        field2 = xo.Float64[:]
-
-    s1 = Struct2(field1=2, field2=5)
+    s2 = Struct2(field1=2, field2=5)
 
     kernels = Struct2._gen_kernels()
     ctx = xo.ContextCpu()
     ctx.add_kernels(kernels=kernels)
 
-    assert ctx.kernels.Struct2_len_field2(obj=s1) == len(s1.field2)
-    for ii in range(len(s1.field2)):
-        s1.field2[ii] = ii * 3
-        assert ctx.kernels.Struct2_get_field2(obj=s1, i0=ii) == ii * 3
-        ctx.kernels.Struct2_set_field2(obj=s1, i0=ii, value=ii * 4)
-        assert s1.field2[ii] == ii * 4
+    assert ctx.kernels.Struct2_len_field2(obj=s2) == len(s2.field2)
+    for ii in range(len(s2.field2)):
+        s2.field2[ii] = ii * 3
+        assert ctx.kernels.Struct2_get_field2(obj=s2, i0=ii) == ii * 3
+        ctx.kernels.Struct2_set_field2(obj=s2, i0=ii, value=ii * 4)
+        assert s2.field2[ii] == ii * 4
 
 
 def test_struct2r():
-    class Struct2r(xo.Struct):
-        field1 = xo.Int32
-        field2 = xo.Ref[xo.Float64[:]]
-
-    s1 = Struct2r(field1=2)
-
-    s1.field2 = 5
+    s2 = Struct2r(field1=2)
+    s2.field2 = 5
 
     kernels = Struct2r._gen_kernels()
     ctx = xo.ContextCpu()
     ctx.add_kernels(kernels=kernels)
 
-    assert ctx.kernels.Struct2r_len_field2(obj=s1) == len(s1.field2)
-    for ii in range(len(s1.field2)):
-        s1.field2[ii] = ii * 3
-        assert ctx.kernels.Struct2r_get_field2(obj=s1, i0=ii) == ii * 3
-        ctx.kernels.Struct2r_set_field2(obj=s1, i0=ii, value=ii * 4)
-        assert s1.field2[ii] == ii * 4
+    assert ctx.kernels.Struct2r_len_field2(obj=s2) == len(s2.field2)
+    for ii in range(len(s2.field2)):
+        s2.field2[ii] = ii * 3
+        assert ctx.kernels.Struct2r_get_field2(obj=s2, i0=ii) == ii * 3
+        ctx.kernels.Struct2r_set_field2(obj=s2, i0=ii, value=ii * 4)
+        assert s2.field2[ii] == ii * 4
+
+
+def test_struct3():
+    s3 = Struct3(
+        field1=3,
+        field2=[1, 2, 3, 4],
+        field3=[11, 12, 13, 14, 15, 16, 17],
+        field4='hello',
+    )
+
+    kernels = Struct3._gen_kernels()
+    ctx = xo.ContextCpu()
+    ctx.add_kernels(kernels=kernels)
+
+    assert ctx.kernels.Struct3_len_field2(obj=s3) == 4
+    assert ctx.kernels.Struct3_len_field3(obj=s3) == 7
+
+    for ii in range(4):
+        assert ctx.kernels.Struct3_get_field2(obj=s3, i0=ii) == ii + 1
+        ctx.kernels.Struct3_set_field2(obj=s3, i0=ii, value=ii * 4)
+        assert s3.field2[ii] == ii * 4
+
+    for ii in range(7):
+        assert ctx.kernels.Struct3_get_field3(obj=s3, i0=ii) == 11 + ii
+        ctx.kernels.Struct3_set_field3(obj=s3, i0=ii, value=ii)
+        assert s3.field3[ii] == ii
+
+
+def test_struct3r():
+    s3 = Struct3r(
+        field1=3,
+        field2=[1, 2, 3, 4],
+        field3=[11, 12, 13, 14, 15, 16, 17],
+    )
+
+    kernels = Struct3r._gen_kernels()
+    ctx = xo.ContextCpu()
+    ctx.add_kernels(kernels=kernels)
+
+    assert ctx.kernels.Struct3r_len_field2(obj=s3) == 4
+    assert ctx.kernels.Struct3r_len_field3(obj=s3) == 7
+
+    for ii in range(4):
+        assert ctx.kernels.Struct3r_get_field2(obj=s3, i0=ii) == ii + 1
+        ctx.kernels.Struct3r_set_field2(obj=s3, i0=ii, value=ii * 4)
+        assert s3.field2[ii] == ii * 4
+
+    for ii in range(7):
+        assert ctx.kernels.Struct3r_get_field3(obj=s3, i0=ii) == 11 + ii
+        ctx.kernels.Struct3r_set_field3(obj=s3, i0=ii, value=ii)
+        assert s3.field3[ii] == ii
+
+
+def test_struct4():
+    af32 = [2.1, 2.2]
+    af64 = [3.1, 3.2, 3.3]
+    ai8 = [-9, -3, 11, 18]
+
+    s4 = Struct4(
+        field1=1.,
+        field2=af32,
+        field3=af64,
+        field4=ai8,
+    )
+
+    kernels = Struct4._gen_kernels()
+    ctx = xo.ContextCpu()
+    ctx.add_kernels(kernels=kernels)
+
+    assert ctx.kernels.Struct4_len_field2(obj=s4) == len(af32)
+    assert ctx.kernels.Struct4_len_field3(obj=s4) == len(af64)
+    assert ctx.kernels.Struct4_len_field4(obj=s4) == len(ai8)
+
+    for ii, expected in enumerate(af32):
+        assert math.isclose(
+            ctx.kernels.Struct4_get_field2(obj=s4, i0=ii),
+            expected,
+            rel_tol=1e-7,  # single precision floats
+        )
+        ctx.kernels.Struct4_set_field2(obj=s4, i0=ii, value=7*expected)
+        assert math.isclose(
+            ctx.kernels.Struct4_get_field2(obj=s4, i0=ii),
+            7 * expected,
+            rel_tol=1e-7,  # single precision float
+        )
+
+    for ii, expected in enumerate(af64):
+        assert math.isclose(
+            ctx.kernels.Struct4_get_field3(obj=s4, i0=ii),
+            expected
+        )
+        ctx.kernels.Struct4_set_field3(obj=s4, i0=ii, value=7*expected)
+        assert math.isclose(
+            ctx.kernels.Struct4_get_field3(obj=s4, i0=ii),
+            7 * expected
+        )
+
+    for ii, expected in enumerate(ai8):
+        assert ctx.kernels.Struct4_get_field4(obj=s4, i0=ii) == expected
+        ctx.kernels.Struct4_set_field4(obj=s4, i0=ii, value=7*expected)
+        assert ctx.kernels.Struct4_get_field4(obj=s4, i0=ii) == 7 * expected
+
+
+def test_struct5():
+    ctx = xo.ContextCpu()
+    buff = ctx.new_buffer(0)
+
+    s1 = Struct1(field1=2, field2=3.0, _buffer=buff)
+    s2 = Struct2(field1=2, field2=[2., 2.], _buffer=buff)
+    s2r = Struct2r(field1=2, field2=s2.field2, _buffer=buff)
+    s3 = Struct3(
+        field1=3,
+        field2=[1, 2, 3, 4],
+        field3=[11, 12, 13, 14, 15, 16, 17],
+        field4='hello',
+        _buffer=buff,
+    )
+    s3r = Struct3r(
+        field1=3,
+        field2=s3.field2,
+        field3=s3.field3,
+        _buffer=buff,
+    )
+    s4 = Struct4(
+        field1=1.,
+        field2=[2.1, 2.2],
+        field3=[3.1, 3.2, 3.3],
+        field4=[-9, -3, 11, 18],
+        _buffer=buff,
+    )
+    s5 = Struct5(
+        field1=s1,
+        field2=s2,
+        field2r=s2r,
+        field3=s3,
+        field3r=s3r,
+        field4=s4,
+        _buffer=buff,
+    )
+    s5.field2r = s5.field2
+    s5.field3r = s5.field3
+
+    kernels = Struct5._gen_kernels()
+    kernels.update(Struct2._gen_kernels())
+    kernels.update(Struct3._gen_kernels())
+    ctx.add_kernels(kernels=kernels)
+    ks = ctx.kernels
+
+    # verify rebound references
+    assert ks.Struct5_getp_field2r(obj=s5) != ks.Struct5_getp_field2(obj=s5)  # copy
+    assert ks.Struct5_getp_field3r(obj=s5) != ks.Struct5_getp_field3(obj=s5)  # copy
+    assert ks.Struct5_getp_field2r_field2(obj=s5) == \
+           ks.Struct2_getp_field2(obj=s5.field2)
+    assert ks.Struct5_getp_field3r_field2(obj=s5) == \
+           ks.Struct3_getp_field2(obj=s5.field3)
+    assert ks.Struct5_getp1_field2r_field2(obj=s5, i0=2) == \
+           ks.Struct2_getp1_field2(obj=s5.field2, i0=2)
+    assert ks.Struct5_getp1_field3r_field2(obj=s5, i0=2) == \
+           ks.Struct3_getp1_field2(obj=s5.field3, i0=2)
+
+    # set some nested values
+    assert ks.Struct5_get_field1_field1(obj=s5) == s5.field1.field1
+    ks.Struct5_set_field1_field1(obj=s5, value=10)
+    assert ks.Struct5_get_field1_field1(obj=s5) == 10
+
+    # check that references also work
+    assert math.isclose(ks.Struct5_get_field2_field2(obj=s5, i0=0), 2)
+    assert math.isclose(ks.Struct5_get_field2r_field2(obj=s5, i0=0), 2)
+    ks.Struct5_set_field2r_field2(obj=s5, value=4, i0=0)
+    assert math.isclose(ks.Struct5_get_field2_field2(obj=s5, i0=0), 4)
+    assert math.isclose(ks.Struct5_get_field2r_field2(obj=s5, i0=0), 4)
+
+    assert ks.Struct5_len_field3r_field3(obj=s5) == 7
+    assert ks.Struct5_len_field3r_field3(obj=s5) == \
+           ks.Struct5_len_field3_field3(obj=s5)
 
 
 def test_unionref():

--- a/tests/test_ref.py
+++ b/tests/test_ref.py
@@ -82,6 +82,53 @@ def test_ref_to_dynamic_type():
             assert mystructref.a[ii] == [7, 8, 9][ii]
 
 
+def test_ref_nested():
+    class S(xo.Struct):
+        f = xo.Float64[:]
+
+    class R(xo.Struct):
+        f = xo.Ref[xo.Float64[:]]
+
+    class B(xo.Struct):
+        s = S
+        r = R
+
+    ctx = xo.ContextCpu()
+    buf = ctx.new_buffer(0)
+
+    s = S(f=[1, 2, 3], _buffer=buf)
+    r = R(f=s.f, _buffer=buf)
+
+    assert np.isclose(r.f, [1, 2, 3]).all()
+    r.f[1] = 20
+    assert np.isclose(s.f, [1, 20, 3]).all()
+
+    b = B(s=s, r=r, _buffer=buf)
+    # now b.s is a copy of s, and b.r.f points to the original s.f
+    assert np.isclose(b.s.f, [1, 20, 3]).all()
+    assert np.isclose(b.r.f, [1, 20, 3]).all()
+
+    # verify that by making a change
+    b.r.f[0] = 10
+    assert np.isclose(b.r.f, [10, 20, 3]).all()
+    assert np.isclose(r.f, [10, 20, 3]).all()
+    assert np.isclose(s.f, [10, 20, 3]).all()
+    # indeed b.s.f did not change, because b.r.f points to s.f
+    assert np.isclose(b.s.f, [1, 20, 3]).all()
+
+    # we can rebind the reference to point to the array in b.s
+    b.r.f = b.s.f
+    assert np.isclose(b.r.f, [1, 20, 3]).all()
+
+    b.s.f[2] = 30
+    # b.r.f and b.s.f are the same
+    assert np.isclose(b.r.f, [1, 20, 30]).all()
+    assert np.isclose(b.s.f, [1, 20, 30]).all()
+    # original s.f and the reference r.f did not change
+    assert np.isclose(r.f, [10, 20, 3]).all()
+    assert np.isclose(s.f, [10, 20, 3]).all()
+
+
 def test_ref_c_api():
     for context in xo.context.get_test_contexts():
         print(f"Test {context}")
@@ -184,9 +231,6 @@ def no_test_array_of_unionrefs():
         for ii in range(10):
             print(f"aoref[{ii}]=", aoref[ii])
             assert aoref[ii].a == 10 * ii
-
-
-import xobjects as xo
 
 
 def test_unionref():

--- a/xobjects/capi.py
+++ b/xobjects/capi.py
@@ -130,11 +130,11 @@ def Index_get_c_offset(part, conf, icount):
     else:
         nd = len(cls._shape)
         strides = []
-        stride_offset = 8 + nd * 8
         for ii in range(nd):
-            sname = f"{inttype} {cls.__name__}_s{ii}"
+            stride_offset = 8 + (len(cls._dshape_idx) * 8) + (ii * 8)
+            sname = f"{cls.__name__}_s{ii}"
             svalue = int_from_obj(f"offset+{stride_offset}", conf)
-            out.append(f"{sname}={svalue};")
+            out.append(f"  {inttype} {sname}={svalue};")
             strides.append(sname)
 
     soffset = "+".join([f"i{ii+icount}*{ss}" for ii, ss in enumerate(strides)])
@@ -164,6 +164,7 @@ def gen_method_offset(path, conf):
             soffset = Ref_get_c_offset(part, conf)
         else:
             soffset = None
+
         if type(soffset) is int:
             offset += soffset
         elif type(soffset) is list:
@@ -311,16 +312,17 @@ def gen_method_len(cls, path, conf):
         arrarg = Arg(Int64, pointer=True)
         pointed = gen_c_pointed(arrarg, conf)
         typearr = gen_pointer("int64_t*", conf)
-        lst.append(f"  {typearr} arr= {pointed};")
+        lst.append(f"  {typearr} arr = {pointed};")
+        dim_len_idx = 1
         terms = []
-        ii = 1
-        for sh in lasttype._shape:
-            if sh is None:
-                terms.append(f"arr[{ii}]")
+        for dim_len in lasttype._shape:
+            if dim_len:
+                terms.append(str(dim_len))
             else:
-                terms.append(str(sh))
-        terms = "*".join(terms)
-        lst.append(f"  return {terms};")
+                terms.append(f"arr[{dim_len_idx}]")
+                dim_len_idx += 1
+        length_expr = "*".join(terms)
+        lst.append(f"  return {length_expr};")
     lst.append("}")
     return "\n".join(lst), kernel
 

--- a/xobjects/capi.py
+++ b/xobjects/capi.py
@@ -143,7 +143,7 @@ def Index_get_c_offset(part, conf, icount):
     if cls._is_static_type:
         out.append(f"  offset+={soffset};")
     else:
-        out.append(int_from_obj(f"offset+{soffset}", conf))
+        out.append(int_from_obj(f"offset+{soffset}", conf) + ";")
     return out
 
 

--- a/xobjects/capi.py
+++ b/xobjects/capi.py
@@ -143,7 +143,8 @@ def Index_get_c_offset(part, conf, icount):
     if cls._is_static_type:
         out.append(f"  offset+={soffset};")
     else:
-        out.append(int_from_obj(f"offset+{soffset}", conf) + ";")
+        lookup_field_offset = f"offset+{soffset}"
+        out.append(f"  offset={int_from_obj(lookup_field_offset, conf)};")
     return out
 
 
@@ -202,7 +203,7 @@ def gen_fun_kernel(cls, path, action, const, extra, ret, add_nindex=False):
 def gen_c_pointed(target: Arg, conf):
     size = gen_c_size_from_arg(target, conf)
     ret = gen_c_type_from_arg(target, conf)
-    if target.pointer or is_compound(target.atype):
+    if target.pointer or is_compound(target.atype) or is_string(target.atype):
         chartype = gen_pointer(conf.get("chartype", "char") + "*", conf)
         return f"({ret})(({chartype}) obj+offset)"
     else:

--- a/xobjects/struct.py
+++ b/xobjects/struct.py
@@ -304,7 +304,7 @@ class Struct(metaclass=MetaStruct):
 
     @classmethod
     def _to_buffer(cls, buffer, offset, value, info=None):
-        if isinstance(value, cls):  # binary copy
+        if isinstance(value, cls) and not cls._has_refs:  # binary copy
             buffer.update_from_xbuffer(
                 offset, value._buffer, value._offset, value._size
             )


### PR DESCRIPTION
Supersedes #61
Closes xsuite/xsuite#178

- add a missing semicolon in `capi.Index_get_c_offset`
- correct the calculation of the right offset (do not discard the value)
- change the return in `capi.gen_c_pointed` so that it does not try to dereference the value of the string
- fix a bug in `Index_get_c_offset` where a type appeared in the wrong place causing compilation issues for dyn-sized arrays
- fix wrong calculation of index offsets in `gen_method_len` for dyn-sized arrays
- fix wrong calculation of index offsets in `Index_get_c_offset` which is needed for `_get` and `_set` kernels
- fix an issue in `struct` where an object with a reference was binary-copied thereby corrupting the reference

