### PR TITLE
update the calls to cl.enqueue_copy to new api

### DIFF
--- a/xobjects/context_pyopencl.py
+++ b/xobjects/context_pyopencl.py
@@ -383,23 +383,23 @@ class BufferPyopencl(XBuffer):
             self.context.queue,
             self.buffer,
             source,
-            src_offset,
-            dest_offset,
-            byte_count,
+            src_offset=src_offset,
+            dst_offset=dest_offset,
+            byte_count=byte_count,
         )
 
     def write(self, offset, data):
         # From python object with buffer interface on cpu
         # log.debug(f"write {self} {offset} {data}")
         cl.enqueue_copy(
-            self.context.queue, self.buffer, data, device_offset=offset
+            self.context.queue, self.buffer, data, src_offset=offset
         )
 
     def read(self, offset, size):
         # To bytearray on cpu
         data = bytearray(size)
         cl.enqueue_copy(
-            self.context.queue, data, self.buffer, device_offset=offset
+            self.context.queue, data, self.buffer, src_offset=offset
         )
         return data
 
@@ -412,7 +412,7 @@ class BufferPyopencl(XBuffer):
             self.buffer,
             source,
             src_offset=source_offset,
-            dest_offset=offset,
+            dst_offset=offset,
             byte_count=nbytes,
         )
 
@@ -446,7 +446,7 @@ class BufferPyopencl(XBuffer):
             queue=self.context.queue,
             dest=self.buffer,
             src=source,  # nbytes taken from min(len(source),len(buffer))
-            device_offset=offset,
+            dst_offset=offset,
         )
 
     def to_nplike(self, offset, dtype, shape):
@@ -471,7 +471,7 @@ class BufferPyopencl(XBuffer):
             queue=self.context.queue,
             dest=data,  # nbytes taken from min(len(data),len(buffer))
             src=self.buffer,
-            device_offset=offset,
+            src_offset=offset,
         )
         return data
 


### PR DESCRIPTION
## Description
<!-- Describe why you are making the changes you do
 and link the relevant issues below. -->

This updates the calls to `cl.enqueue_copy` in `context_pyopencl` to get rid of deprecation warnings.

Fixes xsuite/xsuite#150.

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [x] I have tested also GPU contexts (pyopencl)
