### PR TITLE
[OpenCL] Ensure NULL definition

### DIFF
--- a/xobjects/context_pyopencl.py
+++ b/xobjects/context_pyopencl.py
@@ -51,7 +51,11 @@ openclheader = [
 typedef long int64_t;
 typedef char int8_t;
 typedef unsigned int uint32_t;
-#endif"""
+#endif
+#ifndef NULL
+#define NULL 0L
+#endif
+"""
 ]
 
 if _enabled:


### PR DESCRIPTION
## Description
<!-- Describe why you are making the changes you do
 and link the relevant issues below. -->

While some vendors define NULL, OpenCL C 1.2 does not do so by itself. This PR adds an explicit definition to prevent the following compilation error when trying to run the [simple example](https://xsuite.readthedocs.io/en/latest/singlepart.html#a-simple-example) with OpenCL context on an AMD GPU:
```
Traceback (most recent call last):
  File "/xsuite/example.py", line 32, in <module>
    tracker = xt.Tracker(_context=context, line=line)
  File "/usr/local/lib/python3.10/dist-packages/xtrack/tracker.py", line 92, in __init__
    self._init_track_no_collective(
  File "/usr/local/lib/python3.10/dist-packages/xtrack/tracker.py", line 350, in _init_track_no_collective
    self._build_kernel(save_source_as, compile=compile)
  File "/usr/local/lib/python3.10/dist-packages/xtrack/tracker.py", line 713, in _build_kernel
    context.add_kernels(
  File "/usr/local/lib/python3.10/dist-packages/xobjects/context_pyopencl.py", line 267, in add_kernels
    prg = cl.Program(self.context, specialized_source).build()
  File "/usr/lib/python3/dist-packages/pyopencl/__init__.py", line 536, in build
    self._prg, was_cached = self._build_and_catch_errors(
  File "/usr/lib/python3/dist-packages/pyopencl/__init__.py", line 584, in _build_and_catch_errors
    raise err
pyopencl._cl.RuntimeError: clBuildProgram failed: BUILD_PROGRAM_FAILURE - clBuildProgram failed: BUILD_PROGRAM_FAILURE - clBuildProgram failed: BUILD_PROGRAM_FAILURE

Build on <pyopencl.Device 'gfx906:sramecc+:xnack-' on 'AMD Accelerated Parallel Processing' at 0x5566dca23a50>:

/tmp/comgr-e36730/input/CompileSource:175:25: error: use of undeclared identifier 'NULL'
    if (record_index == NULL){
                        ^
/tmp/comgr-e36730/input/CompileSource:3734:22: error: use of undeclared identifier 'NULL'
    if (io_buffer == NULL){
                     ^
/tmp/comgr-e36730/input/CompileSource:3735:16: error: use of undeclared identifier 'NULL'
        return NULL;
               ^
/tmp/comgr-e36730/input/CompileSource:3742:16: error: use of undeclared identifier 'NULL'
        return NULL;
               ^
/tmp/comgr-e36730/input/CompileSource:3947:16: error: use of undeclared identifier 'NULL'
        return NULL;
               ^
/tmp/comgr-e36730/input/CompileSource:4339:45: error: use of undeclared identifier 'NULL'
    SynchrotronRadiationRecordData record = NULL;
                                            ^
/tmp/comgr-e36730/input/CompileSource:4340:32: error: use of undeclared identifier 'NULL'
    RecordIndex record_index = NULL;
                               ^
7 errors generated.
Error: Failed to compile source (from CL or HIP source to LLVM IR).

```



