### PR TITLE
add _update method to class to avoid overwriting arrays

### DIFF
--- a/tests/test_array.py
+++ b/tests/test_array.py
@@ -234,3 +234,19 @@ def test_init_with_nparray2d():
     m=Mys(m1=np.ones((6,6))*3,m0=np.ones(6) )
     assert m.m1[3,4]==3
     assert m.m0[3]==1
+
+def test_update():
+    class A(xo.Struct):
+       a=xo.Float64[:]
+       b=xo.Float64[10]
+
+    a=A(a=3)
+    with pytest.raises(Exception) as e:
+        a.a=2
+        assert e.type == ValueError
+
+    with pytest.raises(Exception) as e:
+        a.a=[1,2]
+        assert e.type == ValueError
+
+    a.a=[1,2,3]

--- a/tests/test_array.py
+++ b/tests/test_array.py
@@ -199,7 +199,6 @@ def test_array_dshape_dtype():
     assert ss[2][2] == 6
 
 
-
 def test_array_in_struct():
     class Multipole(xo.Struct):
         order = xo.Int64
@@ -228,25 +227,26 @@ def test_init_with_nparray():
 
 def test_init_with_nparray2d():
     class Mys(xo.Struct):
-        m0=xo.Float64[6]
-        m1=xo.Float64[6,6]
+        m0 = xo.Float64[6]
+        m1 = xo.Float64[6, 6]
 
-    m=Mys(m1=np.ones((6,6))*3,m0=np.ones(6) )
-    assert m.m1[3,4]==3
-    assert m.m0[3]==1
+    m = Mys(m1=np.ones((6, 6)) * 3, m0=np.ones(6))
+    assert m.m1[3, 4] == 3
+    assert m.m0[3] == 1
+
 
 def test_update():
     class A(xo.Struct):
-       a=xo.Float64[:]
-       b=xo.Float64[10]
+        a = xo.Float64[:]
+        b = xo.Float64[10]
 
-    a=A(a=3)
+    a = A(a=3)
     with pytest.raises(Exception) as e:
-        a.a=2
+        a.a = 2
         assert e.type == ValueError
 
     with pytest.raises(Exception) as e:
-        a.a=[1,2]
+        a.a = [1, 2]
         assert e.type == ValueError
 
-    a.a=[1,2,3]
+    a.a = [1, 2, 3]

--- a/xobjects/array.py
+++ b/xobjects/array.py
@@ -84,14 +84,16 @@ def get_shape_from_array(value, nd):
     elif hasattr(value, "__len__"):
         shape = (len(value),)
         if len(value) > 0 and nd > 1:
-            shape0 = get_shape_from_array(value[0], nd-1)
+            shape0 = get_shape_from_array(value[0], nd - 1)
             if shape0 == ():
                 return shape
             for i in value[1:]:
-                shapei = get_shape_from_array(i, nd-1)
+                shapei = get_shape_from_array(i, nd - 1)
                 if shapei != shape0:
-                    raise ValueError(f"{value} does not have a "
-                                     f"consistent shape in dimension {nd}")
+                    raise ValueError(
+                        f"{value} does not have a "
+                        f"consistent shape in dimension {nd}"
+                    )
             return shape + shape0
         else:
             return shape
@@ -305,7 +307,7 @@ class Array(metaclass=MetaArray):
             if len(args) == 0:
                 value = None
             elif len(args) == 1:
-                shape = get_shape_from_array(args[0],len(cls._shape))
+                shape = get_shape_from_array(args[0], len(cls._shape))
                 if shape != cls._shape:
                     raise ValueError(f"shape not valid for {args[0]} ")
                 value = args[0]
@@ -581,18 +583,20 @@ class Array(metaclass=MetaArray):
                 )
             cls._itemtype._to_buffer(self._buffer, offset, value)
 
-    def _update(self,value):
+    def _update(self, value):
         if is_integer(value):
-            ll=value
+            ll = value
         else:
-            ll=len(value)
-        if len(self)==ll:
-               self.__class__._to_buffer(self._buffer,self._offset,value)
+            ll = len(value)
+        if len(self) == ll:
+            self.__class__._to_buffer(self._buffer, self._offset, value)
         else:
             if is_integer(value):
                 raise ValueError(f"Cannot specify new length {ll} for {self}")
             else:
-                raise ValueError(f"len({value})={ll} is incompatible with len({self})={len(self)}")
+                raise ValueError(
+                    f"len({value})={ll} is incompatible with len({self})={len(self)}"
+                )
 
     def _get_offset(self, index):
         if isinstance(index, (int, np.integer)):

--- a/xobjects/array.py
+++ b/xobjects/array.py
@@ -581,6 +581,19 @@ class Array(metaclass=MetaArray):
                 )
             cls._itemtype._to_buffer(self._buffer, offset, value)
 
+    def _update(self,value):
+        if is_integer(value):
+            ll=value
+        else:
+            ll=len(value)
+        if len(self)==ll:
+               self.__class__._to_buffer(self._buffer,self._offset,value)
+        else:
+            if is_integer(value):
+                raise ValueError(f"Cannot specify new length {ll} for {self}")
+            else:
+                raise ValueError(f"len({value})={ll} is incompatible with len({self})={len(self)}")
+
     def _get_offset(self, index):
         if isinstance(index, (int, np.integer)):
             index = (index,)


### PR DESCRIPTION
## Description
Before `a.x=value` where `x` is an `xo.Array` would write data of any length starting from the offset of `x` regardless of the size allocated.

## Checklist

Mandatory: 

- [x] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones only in xobjects 
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [x] I have tested also GPU contexts
