### PR TITLE
Make contexts visible in tests

### DIFF
--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -4,15 +4,15 @@
 # ########################################### #
 
 import xobjects as xo
+from xobjects.test_helpers import for_all_test_contexts
 
 
-def test_create_aligned_objects():
-
+@for_all_test_contexts
+def test_create_aligned_objects(test_context):
     for Arr in xo.Float64[3], xo.Float64[16], xo.Float64[17]:
-        for ctx in xo.context.get_test_contexts():
-            buff = ctx.new_buffer(10)
-            assert buff.default_alignment == ctx.minimum_alignment
-            for i in range(4):
-                aa = Arr(_buffer=buff, _offset="aligned")
-                print(ctx, Arr._size, aa._offset)
-                assert aa._offset % ctx.minimum_alignment == 0
+        buff = test_context.new_buffer(10)
+        assert buff.default_alignment == test_context.minimum_alignment
+        for i in range(4):
+            aa = Arr(_buffer=buff, _offset="aligned")
+            print(test_context, Arr._size, aa._offset)
+            assert aa._offset % test_context.minimum_alignment == 0

--- a/tests/test_array.py
+++ b/tests/test_array.py
@@ -10,8 +10,6 @@ import pytest
 
 import xobjects as xo
 
-from xobjects.typeutils import Info
-
 
 def test_get_shape():
     from xobjects.array import get_shape_from_array

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -133,27 +133,3 @@ def test_nplike(test_context):
     arr2 = buff.to_nplike(offset, "float64", (2, 3))
     arr3 = test_context.nparray_from_context_array(arr2)
     assert np.all(arr == arr3)
-
-
-@requires_context('ContextPyopencl')
-@requires_context('ContextCupy')
-def test_type_matrix():
-    import cupy
-    import numpy as np
-    import pyopencl
-
-    sources = []
-    sources.append(bytearray(24))
-    sources.append(np.zeros(24, dtype="uint8"))
-    sources.append(np.zeros((6, 4), dtype="double"))
-    sources.append(np.zeros((6, 2, 4), dtype="double")[:, 1, :])
-
-    import pyopencl.array
-
-    ctx = pyopencl.create_some_context(0)
-    queue = pyopencl.CommandQueue(ctx)
-    sources.append(pyopencl.Buffer(ctx, pyopencl.mem_flags.READ_WRITE, 24))
-    sources.append(pyopencl.array.Array(queue, shape=24, dtype="uint8"))
-    sources.append(
-        pyopencl.array.Array(queue, shape=(6, 2, 4), dtype="uint8")[:, 1, :]
-    )

--- a/tests/test_hybrid_class.py
+++ b/tests/test_hybrid_class.py
@@ -3,12 +3,15 @@
 # Copyright (c) CERN, 2021.                   #
 # ########################################### #
 
+import numpy as np
 import pytest
 
-import numpy as np
 import xobjects as xo
+from xobjects.test_helpers import for_all_test_contexts
 
-def test_hybrid_struct():
+
+@for_all_test_contexts
+def test_hybrid_struct(test_context):
 
     class Element(xo.HybridClass):
         _xofields = {
@@ -22,32 +25,30 @@ def test_hybrid_struct():
             else:
                 self.xoinitialize(n=len(vv), b=np.sum(vv), vv=vv, **kwargs)
 
-    for context in xo.context.get_test_contexts():
-        print(f"Test {context.__class__}")
+    ele = Element([1, 2, 3], _context=test_context)
+    assert ele.n == ele._xobject.n == 3
+    assert ele.b == ele._xobject.b == 6
+    assert ele.vv[1] == ele._xobject.vv[1] == 2
 
-        ele = Element([1, 2, 3], _context=context)
-        assert ele.n == ele._xobject.n == 3
-        assert ele.b == ele._xobject.b == 6
-        assert ele.vv[1] == ele._xobject.vv[1] == 2
+    new_vv = test_context.nparray_to_context_array(np.array([7, 8, 9]))
+    ele.vv = new_vv
+    assert ele.n == ele._xobject.n == 3
+    assert ele.b == ele._xobject.b == 6
+    assert ele.vv[1] == ele._xobject.vv[1] == 8
 
-        new_vv = context.nparray_to_context_array(np.array([7, 8, 9]))
-        ele.vv = new_vv
-        assert ele.n == ele._xobject.n == 3
-        assert ele.b == ele._xobject.b == 6
-        assert ele.vv[1] == ele._xobject.vv[1] == 8
+    ele.n = 5.0
+    assert ele.n == ele._xobject.n == 5
 
-        ele.n = 5.0
-        assert ele.n == ele._xobject.n == 5
+    ele.b = 50
+    assert ele.b == ele._xobject.b == 50.0
 
-        ele.b = 50
-        assert ele.b == ele._xobject.b == 50.0
-
-        dd = ele.to_dict()
-        assert dd["vv"][1] == 8
-        assert isinstance(dd["vv"], np.ndarray)
+    dd = ele.to_dict()
+    assert dd["vv"][1] == 8
+    assert isinstance(dd["vv"], np.ndarray)
 
 
-def test_explicit_buffer():
+@for_all_test_contexts
+def test_explicit_buffer(test_context):
 
     class Element(xo.HybridClass):
         _xofields = {
@@ -58,19 +59,18 @@ def test_explicit_buffer():
         def __init__(self, vv=None, **kwargs):
             self.xoinitialize(n=len(vv), b=np.sum(vv), vv=vv, **kwargs)
 
-    for context in xo.context.get_test_contexts():
-        print(f"Test {context.__class__}")
-        ele1 = Element([1, 2, 3], _context=context)
-        ele2 = Element([7, 8, 9], _buffer=ele1._buffer)
+    ele1 = Element([1, 2, 3], _context=test_context)
+    ele2 = Element([7, 8, 9], _buffer=ele1._buffer)
 
-        assert ele1.vv[1] == ele1._xobject.vv[1] == 2
-        assert ele2.vv[1] == ele2._xobject.vv[1] == 8
-        for ee in [ele1, ele2]:
-            assert ee._buffer is ee._xobject._buffer
-            assert ee._offset == ee._xobject._offset
+    assert ele1.vv[1] == ele1._xobject.vv[1] == 2
+    assert ele2.vv[1] == ele2._xobject.vv[1] == 8
+    for ee in [ele1, ele2]:
+        assert ee._buffer is ee._xobject._buffer
+        assert ee._offset == ee._xobject._offset
 
-        assert ele1._buffer is ele2._buffer
-        assert ele1._offset != ele2._offset
+    assert ele1._buffer is ele2._buffer
+    assert ele1._offset != ele2._offset
+
 
 @pytest.fixture
 def classes_for_test_hybrid_class_no_ref():
@@ -90,6 +90,7 @@ def classes_for_test_hybrid_class_no_ref():
         _rename = {'inner_to_rename': 'inner_renamed'}
 
     return InnerClass, OuterClass
+
 
 def test_nested_hybrid_init_no_ref(classes_for_test_hybrid_class_no_ref):
     InnerClass, OuterClass = classes_for_test_hybrid_class_no_ref
@@ -259,6 +260,7 @@ def test_rename_with_ambiguous_fields_fails():
                 'a': 'b',
                 'b': 'c',
             }
+
 
 def test_move_nested_objects_between_contexts_no_ref(classes_for_test_hybrid_class_no_ref):
     InnerClass, OuterClass = classes_for_test_hybrid_class_no_ref

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -6,6 +6,7 @@
 import numpy as np
 
 import xobjects as xo
+from xobjects.test_helpers import for_all_test_contexts
 
 
 def test_kernel_cpu():
@@ -40,59 +41,58 @@ double my_mul(const int n, const double* x1,
     assert y == 285.0
 
 
-def test_kernels():
-    for ctx in xo.context.get_test_contexts():
-
-        src_code = """
-        /*gpufun*/
-        void myfun(double x, double y,
-            double* z){
-            z[0] = x * y;
-            }
-
-        /*gpukern*/
-        void my_mul(const int n,
-            /*gpuglmem*/ const double* x1,
-            /*gpuglmem*/ const double* x2,
-            /*gpuglmem*/       double* y) {
-            int tid = 0 //vectorize_over tid n
-            double z;
-            myfun(x1[tid], x2[tid], &z);
-            y[tid] = z;
-            //end_vectorize
-            }
-        """
-
-        kernel_descriptions = {
-            "my_mul": xo.Kernel(
-                args=[
-                    xo.Arg(xo.Int32, name="n"),
-                    xo.Arg(xo.Float64, pointer=True, const=True, name="x1"),
-                    xo.Arg(xo.Float64, pointer=True, const=True, name="x2"),
-                    xo.Arg(xo.Float64, pointer=True, const=False, name="y"),
-                ],
-                n_threads="n",
-            ),
+@for_all_test_contexts
+def test_kernels(test_context):
+    src_code = """
+    /*gpufun*/
+    void myfun(double x, double y,
+        double* z){
+        z[0] = x * y;
         }
 
-        # Import kernel in context
-        ctx.add_kernels(
-            sources=[src_code],
-            kernels=kernel_descriptions,
-            # save_src_as=f'_test_{name}.c')
-            save_source_as=None,
-            compile=True
-        )
+    /*gpukern*/
+    void my_mul(const int n,
+        /*gpuglmem*/ const double* x1,
+        /*gpuglmem*/ const double* x2,
+        /*gpuglmem*/       double* y) {
+        int tid = 0 //vectorize_over tid n
+        double z;
+        myfun(x1[tid], x2[tid], &z);
+        y[tid] = z;
+        //end_vectorize
+        }
+    """
 
-        x1_host = np.array([1.0, 2.0, 3.0], dtype=np.float64)
-        x2_host = np.array([7.0, 8.0, 9.0], dtype=np.float64)
+    kernel_descriptions = {
+        "my_mul": xo.Kernel(
+            args=[
+                xo.Arg(xo.Int32, name="n"),
+                xo.Arg(xo.Float64, pointer=True, const=True, name="x1"),
+                xo.Arg(xo.Float64, pointer=True, const=True, name="x2"),
+                xo.Arg(xo.Float64, pointer=True, const=False, name="y"),
+            ],
+            n_threads="n",
+        ),
+    }
 
-        x1_dev = ctx.nparray_to_context_array(x1_host)
-        x2_dev = ctx.nparray_to_context_array(x2_host)
-        y_dev = ctx.zeros(shape=x1_host.shape, dtype=x1_host.dtype)
+    # Import kernel in context
+    test_context.add_kernels(
+        sources=[src_code],
+        kernels=kernel_descriptions,
+        # save_src_as=f'_test_{name}.c')
+        save_source_as=None,
+        compile=True
+    )
 
-        ctx.kernels.my_mul(n=len(x1_host), x1=x1_dev, x2=x2_dev, y=y_dev)
+    x1_host = np.array([1.0, 2.0, 3.0], dtype=np.float64)
+    x2_host = np.array([7.0, 8.0, 9.0], dtype=np.float64)
 
-        y_host = ctx.nparray_from_context_array(y_dev)
+    x1_dev = test_context.nparray_to_context_array(x1_host)
+    x2_dev = test_context.nparray_to_context_array(x2_host)
+    y_dev = test_context.zeros(shape=x1_host.shape, dtype=x1_host.dtype)
 
-        assert np.allclose(y_host, x1_host * x2_host)
+    test_context.kernels.my_mul(n=len(x1_host), x1=x1_dev, x2=x2_dev, y=y_dev)
+
+    y_host = test_context.nparray_from_context_array(y_dev)
+
+    assert np.allclose(y_host, x1_host * x2_host)

--- a/tests/test_linked_array.py
+++ b/tests/test_linked_array.py
@@ -4,9 +4,13 @@
 # ########################################### #
 
 import numpy as np
-import xobjects as xo
 
-def test_linked_arrays():
+import xobjects as xo
+from xobjects.test_helpers import for_all_test_contexts
+
+
+@for_all_test_contexts
+def test_linked_arrays(test_context):
     class MyStruct(xo.HybridClass):
         _xofields = {
             '_a': xo.Float64[:],
@@ -39,49 +43,47 @@ def test_linked_arrays():
                                             self._asq,
                                             mode='readonly')
 
-    for context in xo.context.get_test_contexts():
+    ctx2np = test_context.nparray_from_context_array
+    np2ctx = test_context.nparray_to_context_array
 
-        ctx2np = context.nparray_from_context_array
-        np2ctx = context.nparray_to_context_array
+    m = MyStruct(a=np2ctx(np.array([1.,2.,3.])), _context=test_context)
+    assert np.all(ctx2np(m.a) == np.array([1,2,3]))
+    assert np.all(ctx2np(m.asq) == np.array([1,4,9]))
 
-        m = MyStruct(a=np2ctx(np.array([1.,2.,3.])), _context=context)
-        assert np.all(ctx2np(m.a) == np.array([1,2,3]))
-        assert np.all(ctx2np(m.asq) == np.array([1,4,9]))
+    m.a[1:] = m.a[:2] + 10
+    assert np.all(ctx2np(m.a) == np.array([1, 11, 12]))
+    assert np.all(ctx2np(m.asq) == np.array([1, 121, 144]))
 
-        m.a[1:] = m.a[:2] + 10
-        assert np.all(ctx2np(m.a) == np.array([1, 11, 12]))
-        assert np.all(ctx2np(m.asq) == np.array([1, 121, 144]))
+    m.a = 5
+    assert np.all(ctx2np(m.a) == 5)
+    assert np.all(ctx2np(m.asq) == 25)
 
-        m.a = 5
-        assert np.all(ctx2np(m.a) == 5)
-        assert np.all(ctx2np(m.asq) == 25)
+    b = m.a.copy()
+    assert np.all(ctx2np(m.a) == ctx2np(b))
 
-        b = m.a.copy()
-        assert np.all(ctx2np(m.a) == ctx2np(b))
+    m.a = np2ctx(np.array([4, -5, 6]))
+    b = m.a.copy() + 3
+    assert np.all(ctx2np(m.a - b) == -3)
+    assert np.all(ctx2np(b - m.a) == 3)
+    assert np.all(ctx2np(m.a/(m.a*2)) == 0.5)
+    assert np.all(ctx2np(-m.a) == ctx2np(-10*m.a/10))
 
-        m.a = np2ctx(np.array([4,-5,6]))
-        b = m.a.copy() + 3
-        assert np.all(ctx2np(m.a - b)  == -3)
-        assert np.all(ctx2np(b - m.a)  == 3)
-        assert np.all(ctx2np(m.a/(m.a*2))  == 0.5)
-        assert np.all(ctx2np(-m.a)  == ctx2np(-10*m.a/10))
+    m.a = m.a*2
+    assert np.all(ctx2np(m.a) == np.array([8, -10, 12]))
+    assert np.all(ctx2np(m.asq) == np.array([64, 100, 144]))
 
-        m.a = m.a*2
-        assert np.all(ctx2np(m.a) == np.array([8, -10, 12]))
-        assert np.all(ctx2np(m.asq) == np.array([64, 100, 144]))
+    m.a = np2ctx(np.array([4, -5, 6]))
+    m.a *= 2
+    assert np.all(ctx2np(m.a) == np.array([8, -10, 12]))
+    assert np.all(ctx2np(m.asq) == np.array([64, 100, 144]))
 
-        m.a = np2ctx(np.array([4,-5,6]))
-        m.a *= 2
-        assert np.all(ctx2np(m.a) == np.array([8, -10, 12]))
-        assert np.all(ctx2np(m.asq) == np.array([64, 100, 144]))
+    m.a = np2ctx(np.array([1, 2, 3]))
+    m.a = m.a**2 + 1
+    assert np.all(ctx2np(m.a) == np.array([2, 5, 10]))
+    assert np.all(ctx2np(m.asq) == np.array([4, 25, 100]))
 
-        m.a = np2ctx(np.array([1, 2, 3]))
-        m.a = m.a**2 +1
-        assert np.all(ctx2np(m.a) == np.array([2, 5, 10]))
-        assert np.all(ctx2np(m.asq) == np.array([4, 25, 100]))
-
-        if not(isinstance(context, xo.ContextPyopencl)): # masking not working
-            m.a = np2ctx(np.array([4,-5,6]))
-            m.a[m.a<0] += m.a[:1]
-            assert np.all(ctx2np(m.a) == np.array([4, -1, 6]))
-            assert np.all(ctx2np(m.asq) == np.array([16, 1, 36]))
+    if not(isinstance(test_context, xo.ContextPyopencl)):  # masking not working
+        m.a = np2ctx(np.array([4, -5, 6]))
+        m.a[m.a < 0] += m.a[:1]
+        assert np.all(ctx2np(m.a) == np.array([4, -1, 6]))
+        assert np.all(ctx2np(m.asq) == np.array([16, 1, 36]))

--- a/tests/test_nplike_arrays.py
+++ b/tests/test_nplike_arrays.py
@@ -4,113 +4,106 @@
 # ########################################### #
 
 import numpy as np
+import pytest
 
 import xobjects as xo
+from xobjects.test_helpers import for_all_test_contexts
 
 
-def test_type():
-    for ctx in xo.context.get_test_contexts():
-        print(f"Test {ctx}")
-
-    a = ctx.zeros(10, dtype=np.float64)
-    assert isinstance(a, ctx.nplike_array_type)
+@for_all_test_contexts
+def test_type(test_context):
+    a = test_context.zeros(10, dtype=np.float64)
+    assert isinstance(a, test_context.nplike_array_type)
 
 
-def test_ffts():
+@for_all_test_contexts
+def test_ffts(test_context):
+    if "Pyopencl" in str(test_context):
+        try:
+            import gpyfft
+        except ImportError:
+            print("gpyfft not available")
+            return
 
-    for ctx in xo.context.get_test_contexts():
-        if "Pyopencl" in str(ctx):
-            try:
-                import gpyfft
-            except ImportError:
-                print("gpyfft not available")
-                continue
+    # Test on a square wave
+    n_x = 1000
+    x_host = np.zeros(n_x, dtype=np.complex128)
+    x_host[: n_x // 3] = 1.0
 
-        print(f"Test {ctx}")
+    x_dev = test_context.nparray_to_context_array(x_host)
+    myfft = test_context.plan_FFT(x_dev, axes=(0,))
 
-        # Test on a square wave
-        n_x = 1000
-        x_host = np.zeros(n_x, dtype=np.complex128)
-        x_host[: n_x // 3] = 1.0
+    myfft.transform(x_dev)
+    x_trans = test_context.nparray_from_context_array(x_dev).copy()
 
-        x_dev = ctx.nparray_to_context_array(x_host)
-        myfft = ctx.plan_FFT(x_dev, axes=(0,))
+    myfft.itransform(x_dev)
+    x_itrans = test_context.nparray_from_context_array(x_dev).copy()
 
-        myfft.transform(x_dev)
-        x_trans = ctx.nparray_from_context_array(x_dev).copy()
+    # Profit to test the extraction of the real part
+    x_itrans = test_context.nparray_from_context_array(x_dev.real).copy()
 
-        myfft.itransform(x_dev)
-        x_itrans = ctx.nparray_from_context_array(x_dev).copy()
-
-        # Profit to test the extraction of the real part
-        x_itrans = ctx.nparray_from_context_array(x_dev.real).copy()
-
-        assert np.allclose(x_trans, np.fft.fft(x_host))
-        assert np.allclose(x_itrans, x_host)
+    assert np.allclose(x_trans, np.fft.fft(x_host))
+    assert np.allclose(x_itrans, x_host)
 
 
-def test_slicing():
-    for ctx in xo.context.get_test_contexts():
-        print(f"Test {ctx}")
+@for_all_test_contexts
+@pytest.mark.parametrize('order', ('C', 'F'))
+def test_slicing(order, test_context):
+    n_x = 100
+    a_host = np.array(np.random.rand(n_x, n_x), order=order)
 
-        for order in ("C", "F"):
-            n_x = 100
-            a_host = np.array(np.random.rand(n_x, n_x), order=order)
+    a_dev = test_context.nparray_to_context_array(a_host)
+    b_dev = a_dev[: n_x // 2, : n_x // 3]  # Non-countiguous array
 
-            a_dev = ctx.nparray_to_context_array(a_host)
-            b_dev = a_dev[: n_x // 2, : n_x // 3]  # Non-countiguous array
+    b_host = test_context.nparray_from_context_array(b_dev)
+    assert np.allclose(b_host, a_host[: n_x // 2, : n_x // 3])
 
-            b_host = ctx.nparray_from_context_array(b_dev)
-            assert np.allclose(b_host, a_host[: n_x // 2, : n_x // 3])
+    # Test copy and setattr
+    c_dev = a_dev.copy()[
+        : n_x // 2, : n_x // 3
+    ]  # Non-countiguous array
+    c_dev[: n_x // 2 // 2, : n_x // 3 // 2] = (
+        b_dev[: n_x // 2 // 2, : n_x // 3 // 2].copy() * 3
+    )
 
-            # Test copy and setattr
-            c_dev = a_dev.copy()[
-                : n_x // 2, : n_x // 3
-            ]  # Non-countiguous array
-            c_dev[: n_x // 2 // 2, : n_x // 3 // 2] = (
-                b_dev[: n_x // 2 // 2, : n_x // 3 // 2].copy() * 3
-            )
+    c_host = a_host.copy()[
+        : n_x // 2, : n_x // 3
+    ]  # Non-countiguous array
+    c_host[: n_x // 2 // 2, : n_x // 3 // 2] = (
+        b_host[: n_x // 2 // 2, : n_x // 3 // 2].copy() * 3
+    )
 
-            c_host = a_host.copy()[
-                : n_x // 2, : n_x // 3
-            ]  # Non-countiguous array
-            c_host[: n_x // 2 // 2, : n_x // 3 // 2] = (
-                b_host[: n_x // 2 // 2, : n_x // 3 // 2].copy() * 3
-            )
+    assert np.allclose(c_host, test_context.nparray_from_context_array(c_dev))
 
-            assert np.allclose(c_host, ctx.nparray_from_context_array(c_dev))
-
-            # Check sum
-            assert np.isclose(a_dev.sum(), a_host.sum())
-            assert np.isclose(a_dev[:].sum(), a_host[:].sum())
-            assert np.isclose(c_dev.sum(), c_host.sum())
-            assert np.isclose(c_dev[:].sum(), c_host[:].sum())
+    # Check sum
+    assert np.isclose(a_dev.sum(), a_host.sum())
+    assert np.isclose(a_dev[:].sum(), a_host[:].sum())
+    assert np.isclose(c_dev.sum(), c_host.sum())
+    assert np.isclose(c_dev[:].sum(), c_host[:].sum())
 
 
-def test_nplike_from_xoarray():
-    for ctx in xo.context.get_test_contexts():
-        print(f"Test {ctx}")
+@for_all_test_contexts
+def test_nplike_from_xoarray(test_context):
+    Array = xo.Float64[:]
+    a_xo = Array(10, _context=test_context)
+    a_nl = a_xo.to_nplike()
+    a_nl[2] = 5
+    assert a_xo[2] == 5
 
-        Array = xo.Float64[:]
-        a_xo = Array(10, _context=ctx)
-        a_nl = a_xo.to_nplike()
-        a_nl[2] = 5
-        assert a_xo[2] == 5
+    Array = xo.Float64[10]
+    a_xo = Array(_context=test_context)
+    a_nl = a_xo.to_nplike()
+    a_nl[2] = 5
+    assert a_xo[2] == 5
 
-        Array = xo.Float64[10]
-        a_xo = Array(_context=ctx)
-        a_nl = a_xo.to_nplike()
-        a_nl[2] = 5
-        assert a_xo[2] == 5
+    Array = xo.Float64[:, :]
+    a_xo = Array(10, 20, _context=test_context)
+    a_nl = a_xo.to_nplike()
+    a_nl[2, 3] = 5
+    assert a_xo[2, 3] == 5
 
-        Array = xo.Float64[:, :]
-        a_xo = Array(10, 20, _context=ctx)
-        a_nl = a_xo.to_nplike()
-        a_nl[2, 3] = 5
-        assert a_xo[2, 3] == 5
-
-        Array = xo.Float64[10, 20]
-        a_xo = Array(_context=ctx)
-        a_nl = a_xo.to_nplike()
-        a_nl[2, 3] = 5
-        assert a_xo[2, 3] == 5
+    Array = xo.Float64[10, 20]
+    a_xo = Array(_context=test_context)
+    a_nl = a_xo.to_nplike()
+    a_nl[2, 3] = 5
+    assert a_xo[2, 3] == 5

--- a/tests/test_ref.py
+++ b/tests/test_ref.py
@@ -4,82 +4,80 @@
 # ########################################### #
 
 import numpy as np
+
 import xobjects as xo
+from xobjects.test_helpers import for_all_test_contexts
 
 
-def test_ref_to_static_type():
-    for ctx in xo.context.get_test_contexts():
-        print(f"Test {ctx}")
+@for_all_test_contexts
+def test_ref_to_static_type(test_context):
+    buff = test_context._make_buffer(capacity=1024)
 
-        buff = ctx._make_buffer(capacity=1024)
+    Float64_3 = xo.Float64[3]
 
-        Float64_3 = xo.Float64[3]
+    arr1 = Float64_3([1, 2, 3], _buffer=buff)
+    arr2 = Float64_3([4, 5, 6], _buffer=buff)
 
-        arr1 = Float64_3([1, 2, 3], _buffer=buff)
-        arr2 = Float64_3([4, 5, 6], _buffer=buff)
+    class MyStructRef(xo.Struct):
+        a = xo.Ref[Float64_3]
+        # a = xo.Field(xo.Ref(Float64_3)) # More explicit
 
-        class MyStructRef(xo.Struct):
-            a = xo.Ref[Float64_3]
-            # a = xo.Field(xo.Ref(Float64_3)) # More explicit
+    assert MyStructRef._size == 8
 
-        assert MyStructRef._size == 8
+    mystructref = MyStructRef(a=arr2, _buffer=buff)
 
-        mystructref = MyStructRef(a=arr2, _buffer=buff)
+    assert mystructref._size == 8
+    assert (
+        mystructref.a._offset == arr2._offset
+    )  # Points to the same object
+    for ii in range(3):
+        assert mystructref.a[ii] == arr2[ii]
 
-        assert mystructref._size == 8
-        assert (
-            mystructref.a._offset == arr2._offset
-        )  # Points to the same object
-        for ii in range(3):
-            assert mystructref.a[ii] == arr2[ii]
+    mystructref.a = arr1
+    assert (
+        mystructref.a._offset == arr1._offset
+    )  # Points to the same object
+    for ii in range(3):
+        assert mystructref.a[ii] == arr1[ii]
 
-        mystructref.a = arr1
-        assert (
-            mystructref.a._offset == arr1._offset
-        )  # Points to the same object
-        for ii in range(3):
-            assert mystructref.a[ii] == arr1[ii]
-
-        mystructref.a = [7, 8, 9]
-        for ii in range(3):
-            assert mystructref.a[ii] == [7, 8, 9][ii]
+    mystructref.a = [7, 8, 9]
+    for ii in range(3):
+        assert mystructref.a[ii] == [7, 8, 9][ii]
 
 
-def test_ref_to_dynamic_type():
-    for ctx in xo.context.get_test_contexts():
-        print(f"Test {ctx}")
+@for_all_test_contexts
+def test_ref_to_dynamic_type(test_context):
+    buff = test_context._make_buffer(capacity=1024)
 
-        buff = ctx._make_buffer(capacity=1024)
+    arr1 = xo.Float64[:]([1, 2, 3], _buffer=buff)
+    arr2 = xo.Float64[:]([4, 5, 6, 7], _buffer=buff)
 
-        arr1 = xo.Float64[:]([1, 2, 3], _buffer=buff)
-        arr2 = xo.Float64[:]([4, 5, 6, 7], _buffer=buff)
+    class MyStructRef(xo.Struct):
+        a = xo.Ref[xo.Float64[:]]
 
-        class MyStructRef(xo.Struct):
-            a = xo.Ref[xo.Float64[:]]
+    assert MyStructRef._size == 8
 
-        assert MyStructRef._size == 8
+    mystructref = MyStructRef(a=arr2, _buffer=buff)
+    assert (
+        mystructref.a._offset == arr2._offset
+    )  # Points to the same object
+    assert mystructref._size == 8
+    for ii in range(4):
+        assert mystructref.a[ii] == arr2[ii]
 
-        mystructref = MyStructRef(a=arr2, _buffer=buff)
-        assert (
-            mystructref.a._offset == arr2._offset
-        )  # Points to the same object
-        assert mystructref._size == 8
-        for ii in range(4):
-            assert mystructref.a[ii] == arr2[ii]
+    mystructref.a = arr1
+    assert (
+        mystructref.a._offset == arr1._offset
+    )  # Points to the same object
+    for ii in range(3):
+        assert mystructref.a[ii] == arr1[ii]
 
-        mystructref.a = arr1
-        assert (
-            mystructref.a._offset == arr1._offset
-        )  # Points to the same object
-        for ii in range(3):
-            assert mystructref.a[ii] == arr1[ii]
-
-        mystructref.a = [
-            7,
-            8,
-        ]
-        for ii in range(2):
-            assert mystructref.a[ii] == [7, 8, 9][ii]
+    mystructref.a = [
+        7,
+        8,
+    ]
+    for ii in range(2):
+        assert mystructref.a[ii] == [7, 8, 9][ii]
 
 
 def test_ref_nested():
@@ -129,58 +127,53 @@ def test_ref_nested():
     assert np.isclose(s.f, [10, 20, 3]).all()
 
 
-def test_ref_c_api():
-    for context in xo.context.get_test_contexts():
-        print(f"Test {context}")
+@for_all_test_contexts
+def test_ref_c_api(test_context):
+    class MyStruct(xo.Struct):
+        a = xo.Float64[:]
 
-        class MyStruct(xo.Struct):
-            a = xo.Float64[:]
+    class MyStruct2(xo.Struct):
+        a = xo.Float64[:]
+        sr = xo.Ref(MyStruct)
 
-        class MyStruct2(xo.Struct):
-            a = xo.Float64[:]
-            sr = xo.Ref(MyStruct)
+    ms = MyStruct(a=[1, 2, 3], _context=test_context)
 
-        ms = MyStruct(a=[1, 2, 3], _context=context)
+    ms2 = MyStruct2(_buffer=ms._buffer, sr=ms, a=[0, 0, 0])
 
-        ms2 = MyStruct2(_buffer=ms._buffer, sr=ms, a=[0, 0, 0])
+    src = r"""
+    /*gpukern*/
+    void cp_sra_to_a(MyStruct2 ms, int64_t n){
 
-        src = r"""
-        /*gpukern*/
-        void cp_sra_to_a(MyStruct2 ms, int64_t n){
+        for(int64_t ii=0; ii<n; ii++){ //vectorize_over ii n
+            double const val = MyStruct2_get_sr_a(ms, ii);
+            MyStruct2_set_a(ms, ii, val);
+        }//end_vectorize
 
-            for(int64_t ii=0; ii<n; ii++){ //vectorize_over ii n
-                double const val = MyStruct2_get_sr_a(ms, ii);
-                MyStruct2_set_a(ms, ii, val);
-            }//end_vectorize
+    }
+    """
 
-        }
-        """
+    test_context.add_kernels(
+        sources=[src],
+        kernels={
+            "cp_sra_to_a": xo.Kernel(
+                args=[
+                    xo.Arg(MyStruct2, name="ms"),
+                    xo.Arg(xo.Int64, name="n"),
+                ],
+                n_threads="n",
+            )
+        },
+    )
 
-        context.add_kernels(
-            sources=[src],
-            kernels={
-                "cp_sra_to_a": xo.Kernel(
-                    args=[
-                        xo.Arg(MyStruct2, name="ms"),
-                        xo.Arg(xo.Int64, name="n"),
-                    ],
-                    n_threads="n",
-                )
-            },
-        )
+    test_context.kernels.cp_sra_to_a(ms=ms2, n=len(ms.a))
 
-        context.kernels.cp_sra_to_a(ms=ms2, n=len(ms.a))
-
-        for vv, ww in zip(ms2.a, ms2.sr.a):
-            assert vv == ww
+    for vv, ww in zip(ms2.a, ms2.sr.a):
+        assert vv == ww
 
 
-def no_test_unionref():
-
-    for ctx in xo.context.get_test_contexts():
-        print(f"Test {ctx}")
-
-        arr = xo.Float64[:]([1, 2, 3], _context=ctx)
+@for_all_test_contexts
+def no_test_unionref(test_context):
+        arr = xo.Float64[:]([1, 2, 3], _context=test_context)
         buf = arr._buffer
         string = xo.String("Test", _buffer=buf)
 
@@ -201,7 +194,8 @@ def no_test_unionref():
         assert mystructref.a == "Test"
 
 
-def no_test_array_of_unionrefs():
+@for_all_test_contexts
+def no_test_array_of_unionrefs(test_context):
     class MyStructA(xo.Struct):
         a = xo.Float64
 
@@ -211,29 +205,27 @@ def no_test_array_of_unionrefs():
     Element = xo.Ref[MyStructA, MyStructB]
     ArrOfUnionRefs = Element[:]
 
-    for ctx in xo.context.get_test_contexts():
-        print(f"Test {ctx}")
+    aoref = ArrOfUnionRefs(10, _context=test_context)
 
-        aoref = ArrOfUnionRefs(10, _context=ctx)
+    for ii in range(10):
+        if np.mod(ii, 2) == 0:
+            # Even elements
+            temp = MyStructA()
+        else:
+            # Odd elements
+            temp = MyStructB(a=10, _buffer=aoref._buffer)
+        aoref[ii] = temp
 
-        for ii in range(10):
-            if np.mod(ii, 2) == 0:
-                # Even elements
-                temp = MyStructA()
-            else:
-                # Odd elements
-                temp = MyStructB(a=10, _buffer=aoref._buffer)
-            aoref[ii] = temp
+    for ii in range(10):
+        aoref[ii].a = 10 * ii
 
-        for ii in range(10):
-            aoref[ii].a = 10 * ii
-
-        for ii in range(10):
-            print(f"aoref[{ii}]=", aoref[ii])
-            assert aoref[ii].a == 10 * ii
+    for ii in range(10):
+        print(f"aoref[{ii}]=", aoref[ii])
+        assert aoref[ii].a == 10 * ii
 
 
-def test_unionref():
+@for_all_test_contexts
+def test_unionref(test_context):
     class Triangle(xo.Struct):
         b = xo.Float64
         h = xo.Float64
@@ -284,29 +276,27 @@ def test_unionref():
             }
             """]
 
-    for context in xo.context.get_test_contexts():
-        print(f"Test {context}")
+    test_context.add_kernels(
+        kernels={
+            "Prism_compute_volume": xo.Kernel(
+                args=[xo.Arg(Prism, name="prism")]
+            )
+        }
+    )
 
-        context.add_kernels(
-            kernels={
-                "Prism_compute_volume": xo.Kernel(
-                    args=[xo.Arg(Prism, name="prism")]
-                )
-            }
-        )
+    triangle = Triangle(b=2, h=3, _context=test_context)
+    prism_triangle = Prism(base=triangle, height=5, _context=test_context)
+    square = Square(a=2, _context=test_context)
+    prism_square = Prism(base=square, height=10, _context=test_context)
 
-        triangle = Triangle(b=2, h=3, _context=context)
-        prism_triangle = Prism(base=triangle, height=5, _context=context)
-        square = Square(a=2, _context=context)
-        prism_square = Prism(base=square, height=10, _context=context)
+    test_context.kernels.Prism_compute_volume(prism=prism_triangle)
+    test_context.kernels.Prism_compute_volume(prism=prism_square)
 
-        context.kernels.Prism_compute_volume(prism=prism_triangle)
-        context.kernels.Prism_compute_volume(prism=prism_square)
+    assert prism_triangle.volume == 45
+    assert prism_square.volume == 120
 
-        assert prism_triangle.volume == 45
-        assert prism_square.volume == 120
+    assert prism_triangle._has_refs
 
-        assert prism_triangle._has_refs
 
 def test_has_refs():
 
@@ -346,4 +336,3 @@ def test_has_refs():
     class MyUnion(xo.UnionRef):
         _ref = [xo.Float64, xo.Int32]
     assert MyUnion._has_refs
-

--- a/tests/test_scalars.py
+++ b/tests/test_scalars.py
@@ -4,6 +4,7 @@
 # ########################################### #
 
 import xobjects as xo
+from xobjects.test_helpers import for_all_test_contexts
 
 scalars = (
     xo.Float64,
@@ -27,14 +28,13 @@ def test_scalar_class():
         assert info2.size == sc._size
 
 
-def test_scalar_buffer():
+@for_all_test_contexts
+def test_scalar_buffer(test_context):
     nn = 123
-    for ctx in xo.context.get_test_contexts():
-        print(f"Test {ctx}")
-        buff = ctx.new_buffer()
-        for sc in scalars:
-            offset = buff.allocate(sc._size)
-            sc._to_buffer(buff, offset, nn)
-            vv = sc._from_buffer(buff, offset)
-            assert nn == vv
-            assert nn == sc(nn)
+    buff = test_context.new_buffer()
+    for sc in scalars:
+        offset = buff.allocate(sc._size)
+        sc._to_buffer(buff, offset, nn)
+        vv = sc._from_buffer(buff, offset)
+        assert nn == vv
+        assert nn == sc(nn)

--- a/tests/test_string.py
+++ b/tests/test_string.py
@@ -4,6 +4,7 @@
 # ########################################### #
 
 import xobjects as xo
+from xobjects.test_helpers import for_all_test_contexts
 
 
 def test_string_class():
@@ -29,21 +30,21 @@ def test_string_init2():
     assert ss.to_str() == "test"
 
 
-def test_string_init3():
-    for ctx in xo.context.get_test_contexts():
-        ss = xo.String("test", _context=ctx)
-        assert xo.String._from_buffer(ss._buffer, ss._offset) == "test"
+@for_all_test_contexts
+def test_string_init3(test_context):
+    ss = xo.String("test", _context=test_context)
+    assert xo.String._from_buffer(ss._buffer, ss._offset) == "test"
 
-def test_string_array():
+
+@for_all_test_contexts
+def test_string_array(test_context):
     import numpy as np
-    StringArray=xo.String[:]
-    pdata=["asd","as"]
-    npdata=np.array(pdata)
-    for ctx in xo.context.get_test_contexts():
-        xobj=StringArray(npdata,_context=ctx)
-        assert npdata[1]==xobj[1]
-    for ctx in xo.context.get_test_contexts():
-        xobj=StringArray(pdata,_context=ctx)
-        assert pdata[1]==xobj[1]
+    StringArray = xo.String[:]
+    pdata = ["asd", "as"]
+    npdata = np.array(pdata)
 
+    xobj = StringArray(npdata, _context=test_context)
+    assert npdata[1] == xobj[1]
 
+    xobj = StringArray(pdata, _context=test_context)
+    assert pdata[1] == xobj[1]

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -4,8 +4,7 @@
 # ########################################### #
 
 import xobjects as xo
-
-from xobjects.typeutils import Info
+from xobjects.test_helpers import for_all_test_contexts
 
 
 def test_static_struct_def():
@@ -21,7 +20,8 @@ def test_static_struct_def():
     assert StructA.c.index == 2
 
 
-def test_static_struct():
+@for_all_test_contexts
+def test_static_struct(test_context):
     class StructA(xo.Struct):
         a = xo.Field(xo.Float64, default=3.5)
         b = xo.Int8
@@ -33,24 +33,22 @@ def test_static_struct():
     assert StructA.b.index == 1
     assert StructA.c.index == 2
 
-    for ctx in xo.context.get_test_contexts():
-        print(f"Test {ctx}")
+    s = StructA(_context=test_context)
 
-        s = StructA(_context=xo.ContextCpu())
+    assert s._size is not None
+    assert s.a == 3.5
+    assert s.b == 0
+    assert s.c == 0.0
 
-        assert s._size is not None
-        assert s.a == 3.5
-        assert s.b == 0
-        assert s.c == 0.0
-
-        s.a = 5.2
-        assert s.a == 5.2
-        s.c = 7
-        assert s.c == 7
-        s.b = -4
+    s.a = 5.2
+    assert s.a == 5.2
+    s.c = 7
+    assert s.c == 7
+    s.b = -4
 
 
-def test_nested_struct():
+@for_all_test_contexts
+def test_nested_struct(test_context):
     class StructB(xo.Struct):
         a = xo.Field(xo.Float64, default=3.5)
         b = xo.Field(xo.Int64, default=-4)
@@ -64,18 +62,16 @@ def test_nested_struct():
     assert StructB._size is not None
     assert StructC._size is not None
 
-    for ctx in xo.context.get_test_contexts():
-        print(f"Test {ctx}")
+    b = StructC(_context=test_context)
 
-        b = StructC(_context=ctx)
-
-        assert b._size is not None
-        assert b.a == 3.6
-        assert b.b.a == 3.5
-        assert b.b.c == 0
+    assert b._size is not None
+    assert b.a == 3.6
+    assert b.b.a == 3.5
+    assert b.b.c == 0
 
 
-def test_dynamic_struct():
+@for_all_test_contexts
+def test_dynamic_struct(test_context):
     class StructD(xo.Struct):
         a = xo.Field(xo.Float64, default=3.5)
         b = xo.Field(xo.String, default=10)
@@ -83,17 +79,15 @@ def test_dynamic_struct():
 
     assert StructD._size is None
 
-    for ctx in xo.context.get_test_contexts():
-        print(f"Test {ctx}")
-
-        d = StructD(b="this is a test", _context=ctx)
-        assert d._size is not None
-        assert d.a == 3.5
-        assert d.b == "this is a test"
-        assert d.c == -1
+    d = StructD(b="this is a test", _context=test_context)
+    assert d._size is not None
+    assert d.a == 3.5
+    assert d.b == "this is a test"
+    assert d.c == -1
 
 
-def test_dynamic_nested_struct():
+@for_all_test_contexts
+def test_dynamic_nested_struct(test_context):
     class StructE(xo.Struct):
         a = xo.Field(xo.Float64, default=3.5)
         b = xo.Field(xo.String, default=10)
@@ -116,17 +110,15 @@ def test_dynamic_nested_struct():
     assert info.size == 80
     assert info._offsets == {2: 32}
 
-    for ctx in xo.context.get_test_contexts():
-        print(f"Test {ctx}")
-
-        s = StructF(g={"b": "this is a test"}, _context=ctx)
-        assert s._size is not None
-        assert s.e == 3.5
-        assert s.f == 1.5
-        assert s.g.b == "this is a test"
+    s = StructF(g={"b": "this is a test"}, _context=test_context)
+    assert s._size is not None
+    assert s.e == 3.5
+    assert s.f == 1.5
+    assert s.g.b == "this is a test"
 
 
-def test_assign_full_struct():
+@for_all_test_contexts
+def test_assign_full_struct(test_context):
     class StructE(xo.Struct):
         a = xo.Field(xo.Float64, default=3.5)
         b = xo.Field(xo.String, default=10)
@@ -141,17 +133,14 @@ def test_assign_full_struct():
     assert StructE._size is None
     assert StructF._size is None
 
-    for ctx in xo.context.get_test_contexts():
-        print(f"Test {ctx}")
+    s = StructF(g={"b": "this is a test"}, _context=test_context)
+    assert s._size is not None
+    assert s.e == 3.5
+    assert s.f == 1.5
+    assert s.g.b == "this is a test"
 
-        s = StructF(g={"b": "this is a test"}, _context=ctx)
-        assert s._size is not None
-        assert s.e == 3.5
-        assert s.f == 1.5
-        assert s.g.b == "this is a test"
-
-        e = StructE(b="hello")
-        s.g = e
+    e = StructE(b="hello")
+    s.g = e
     # assert f.h==-1
 
 
@@ -202,10 +191,10 @@ def test_nestednested():
     class MyStructB(xo.Struct):
         s = MyStructA
 
-    b = MyStructB(s={'a':10, 'b':10})
+    b = MyStructB(s={'a': 10, 'b': 10})
 
-    assert b.s.a._size==96
-    assert b.s.b._size==96
-    assert b.s._size==208
-    assert b._size==216
+    assert b.s.a._size == 96
+    assert b.s.b._size == 96
+    assert b.s._size == 208
+    assert b._size == 216
 

--- a/xobjects/context.py
+++ b/xobjects/context.py
@@ -445,7 +445,7 @@ def get_context_from_string(ctxstr):
     import xobjects as xo
 
     if ctxstr is None:
-        return xo.ContexCPU()
+        return xo.ContextCpu()
     else:
         ll = ctxstr.split(":")
         if len(ll) <= 1:

--- a/xobjects/test_helpers.py
+++ b/xobjects/test_helpers.py
@@ -1,0 +1,37 @@
+# copyright ################################# #
+# This file is part of the Xobjects Package.  #
+# Copyright (c) CERN, 2022.                   #
+# ########################################### #
+
+from contextlib import contextmanager
+from functools import wraps
+from typing import List
+
+import pytest
+
+from .context import get_context_from_string, get_test_contexts
+
+
+def for_all_test_contexts(test_function):
+    """Parametrize the decorated test over all test contexts with the argument
+    `test_context`."""
+    test_context_names = (type(ctx).__name__ for ctx in get_test_contexts())
+
+    @wraps(test_function)
+    def actual_test(*args, **kwargs):
+        kwargs['test_context'] = get_context_from_string(kwargs['test_context'])
+        test_function(*args, **kwargs)
+
+    return pytest.mark.parametrize(
+        'test_context',
+        test_context_names,
+    )(actual_test)
+
+
+def requires_context(context_name: str):
+    ctx_names = (type(ctx).__name__ for ctx in get_test_contexts())
+
+    if {context_name} & set(ctx_names):  # proceed as normal
+        return lambda test_function: test_function
+
+    return pytest.mark.skip(f'Unavailable on this platform: {context_name}')


### PR DESCRIPTION
## Description

Introduce the following test decorators:

- `for_all_test_contexts` parametrizes a test to run on all test contexts, by passing a `test_context` parameter to the test. The parametrized test are annotated in pytest output, so that if an error occurs, (1) it is easy to track down the contexts where the error occurred, (2) one context failing still allows the tests to run on the remaining contexts. Finally, what will be useful for xtrack/xpart is that in case of a test being retried, only the offending context needs to
  be rerun.
- `requires_context` skips the test if the specified context is unavailable

Closes xsuite/xsuite#167.
Closes xsuite/xsuite#228.
Part of the solution for xsuite/xsuite#190.

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [x] I have updated the docs in relation to my changes, if applicable
- [x] I have tested also GPU contexts
