### PR TITLE
allow saving kernel shared objects

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,6 @@ setup(
             "Source Code": "https://github.com/xsuite/xobjects",
         },
     extras_require={
-        'tests': ['pytest'],
+        'tests': ['pytest', 'pytest-mock'],
     },
 )

--- a/tests/test_capi.py
+++ b/tests/test_capi.py
@@ -5,13 +5,13 @@
 
 # pylint:disable=E1101
 
-import pytest
 import math
-import numpy as np
+
 import cffi
+import numpy as np
+import pytest
 
 import xobjects as xo
-
 
 ffi = cffi.FFI()
 
@@ -492,7 +492,7 @@ def test_getp1_dyn_length_dyn_type_array():
     kernels = ArrNArr._gen_kernels()
     kernels.update(ArrNUint8._gen_kernels())
     ctx = xo.ContextCpu()
-    ctx.add_kernels(kernels=kernels, save_source_as='test-int.c')
+    ctx.add_kernels(kernels=kernels)
 
     assert ctx.kernels.ArrNArrNUint8_len(obj=ary) == 2
 
@@ -508,7 +508,7 @@ def test_getp1_dyn_length_dyn_type_string_array():
 
     kernels = ArrNString._gen_kernels()
     ctx = xo.ContextCpu()
-    ctx.add_kernels(kernels=kernels, save_source_as='test.c')
+    ctx.add_kernels(kernels=kernels)
 
     assert ctx.kernels.ArrNString_len(obj=string_array) == 3
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,0 +1,116 @@
+# copyright ################################# #
+# This file is part of the Xobjects Package.  #
+# Copyright (c) CERN, 2022.                   #
+# ########################################### #
+import shutil
+import sys
+
+import cffi
+import pytest
+
+import xobjects as xo
+
+
+@pytest.fixture
+def cleanup_test_module():
+    yield
+    shutil.rmtree('./some_test')
+
+
+def test_context_cpu_add_kernels_retain(mocker, cleanup_test_module):
+    context = xo.ContextCpu()
+
+    test_src = """
+        int32_t test_function() {
+            return 42;
+        }
+    """
+
+    kernels = {
+        'test_function': xo.Kernel(
+            args=[],
+            c_name='test_function',
+            ret=xo.Arg(xo.Int32),
+        )
+    }
+
+    context.add_kernels(
+        sources=[test_src],
+        kernels=kernels,
+        built_ffi_module_name='some_test.package.test_module',
+        compile=True,
+    )
+
+    # Check if the kernel works
+    assert context.kernels.test_function() == 42
+
+    cffi_compile = mocker.patch.object(cffi.FFI, 'compile')
+    fresh_context = xo.ContextCpu()
+    fresh_context.add_kernels(
+        kernels=kernels,
+        built_ffi_module_name='some_test.package.test_module',
+        compile=False,
+    )
+
+    # Check that the new kernel works
+    assert fresh_context.kernels.test_function() == 42
+
+    # And that it was not recompiled
+    cffi_compile.assert_not_called()
+
+
+@pytest.fixture
+def fake_existing_package(tmp_path, mocker):
+    original_path = sys.path.copy()
+    sys.path.append(str(tmp_path))
+
+    sys.path.append(str(tmp_path))
+    test_package = tmp_path / 'test_package'
+    test_package.mkdir()
+    init = test_package / '__init__.py'
+    init.write_text('')
+
+    yield test_package
+
+    sys.path = original_path
+
+
+def test_context_cpu_add_kernels_existing_package(fake_existing_package):
+    context = xo.ContextCpu()
+
+    test_src = """
+            int32_t test_function() {
+                return 7;
+            }
+        """
+
+    kernels = {
+        'test_function': xo.Kernel(
+            args=[],
+            c_name='test_function',
+            ret=xo.Arg(xo.Int32),
+        )
+    }
+
+    context.add_kernels(
+        sources=[test_src],
+        kernels=kernels,
+        built_ffi_module_name='test_package.test_module',
+        compile=True,
+    )
+
+    # Check that the generated module can be used
+    import test_package.test_module  # noqa
+
+    # Check if the kernel works
+    assert context.kernels.test_function() == 7
+
+    # Check that the dll was created in the right place
+    dll_exists = False
+    for file in fake_existing_package.iterdir():
+        if not file.name.startswith('test_module'):
+            continue
+        if file.suffix not in ['.so', '.dll', '.dylib', '.pyd']:
+            continue
+        dll_exists = True
+    assert dll_exists


### PR DESCRIPTION
## Description

Add a functionality that allows retaining and reloading kernels to ContextCpu.

Add a new parameter `built_ffi_module_name` to `ContextCpu.add_kernels` with the following behaviour:

- `built_ffi_module_name` (`str`): name of the module (either existing, or one to be produced) into which the kernel is compiled. If such a module exists and `compile == False`, it will be attached to the kernel object. If `compile == True`, then the module will be (re)created.

## Checklist

Mandatory: 

- [x] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
