### PR TITLE
Fix indentation

### DIFF
--- a/xobjects/hybrid_class.py
+++ b/xobjects/hybrid_class.py
@@ -162,7 +162,7 @@ class MetaHybridClass(type):
 
             setattr(new_class, pyname, _FieldOfDressed(fname, _XoStruct))
 
-            new_class._fields = pynames_list
+        new_class._fields = pynames_list
 
         _XoStruct._DressingClass = new_class
 


### PR DESCRIPTION
Fix error `object has no attribute '_fields'` for new elements with an empty `_xofields` dict.

Required for https://github.com/xsuite/xtrack/pull/252
