### PR TITLE
build against OpenCL 2.0

### DIFF
--- a/xobjects/context_pyopencl.py
+++ b/xobjects/context_pyopencl.py
@@ -268,7 +268,9 @@ class ContextPyopencl(XContext):
             with open(save_source_as, "w") as fid:
                 fid.write(specialized_source)
 
-        prg = cl.Program(self.context, specialized_source).build()
+        prg = cl.Program(self.context, specialized_source).build(
+            options='-cl-std=CL2.0',
+        )
 
         for pyname, kernel in kernels.items():
             if kernel.c_name is None:


### PR DESCRIPTION
## Description

See issue https://github.com/xsuite/xsuite/issues/247. We should be able to fix it (at least for now) by requiring OpenCL 2.

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [ ] All the tests are passing, including my new ones
- [ ] I described my changes in this PR description

Optional:

- [ ] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
