### PR TITLE
Release/v0.1.31

### DIFF
--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -3,10 +3,12 @@
 # Copyright (c) CERN, 2021.                   #
 # ########################################### #
 
+import sysconfig
+
 import numpy as np
 
 import xobjects as xo
-from xobjects.test_helpers import for_all_test_contexts
+from xobjects.test_helpers import for_all_test_contexts, requires_context
 
 
 def test_kernel_cpu():
@@ -96,3 +98,102 @@ def test_kernels(test_context):
     y_host = test_context.nparray_from_context_array(y_dev)
 
     assert np.allclose(y_host, x1_host * x2_host)
+
+
+@for_all_test_contexts
+def test_kernels_manual_add(test_context):
+    src_code = """
+    /*gpufun*/
+    void myfun(double x, double y,
+        double* z){
+        z[0] = x * y;
+        }
+
+    /*gpukern*/
+    void my_mul(const int n,
+        /*gpuglmem*/ const double* x1,
+        /*gpuglmem*/ const double* x2,
+        /*gpuglmem*/       double* y) {
+        int tid = 0 //vectorize_over tid n
+        double z;
+        myfun(x1[tid], x2[tid], &z);
+        y[tid] = z;
+        //end_vectorize
+        }
+    """
+
+    kernel_descriptions = {
+        "my_mul": xo.Kernel(
+            args=[
+                xo.Arg(xo.Int32, name="n"),
+                xo.Arg(xo.Float64, pointer=True, const=True, name="x1"),
+                xo.Arg(xo.Float64, pointer=True, const=True, name="x2"),
+                xo.Arg(xo.Float64, pointer=True, const=False, name="y"),
+            ],
+            n_threads="n",
+        ),
+    }
+
+    # Import kernel in context
+    kernels = test_context.build_kernels(
+        sources=[src_code],
+        kernel_descriptions=kernel_descriptions,
+        save_source_as=None,
+        compile=True,
+    )
+    test_context.kernels.update(kernels)
+
+    x1_host = np.array([1.0, 2.0, 3.0], dtype=np.float64)
+    x2_host = np.array([7.0, 8.0, 9.0], dtype=np.float64)
+
+    x1_dev = test_context.nparray_to_context_array(x1_host)
+    x2_dev = test_context.nparray_to_context_array(x2_host)
+    y_dev = test_context.zeros(shape=x1_host.shape, dtype=x1_host.dtype)
+
+    test_context.kernels.my_mul(n=len(x1_host), x1=x1_dev, x2=x2_dev, y=y_dev)
+
+    y_host = test_context.nparray_from_context_array(y_dev)
+
+    assert np.allclose(y_host, x1_host * x2_host)
+
+
+@requires_context("ContextCpu")
+def test_kernels_save_files(tmp_path):
+    test_context = xo.ContextCpu()
+    my_folder = tmp_path / "my_folder"
+
+    src_code = """
+        /*gpufun*/
+        double myfun(double x, double y){
+            return x * y;
+        }
+        """
+
+    kernel_descriptions = {
+        "myfun": xo.Kernel(
+            args=[
+                xo.Arg(xo.Float64, name="x"),
+                xo.Arg(xo.Float64, name="y"),
+            ],
+            ret=xo.Arg(xo.Float64),
+        ),
+    }
+
+    kernels = test_context.build_kernels(
+        sources=[src_code],
+        kernel_descriptions=kernel_descriptions,
+        save_source_as="my_module.c",
+        compile=True,
+        containing_dir=str(my_folder),
+        module_name="my_module",
+    )
+    test_context.kernels.update(kernels)
+
+    assert kernels["myfun"].function(3, 4) == 12
+
+    assert my_folder.exists()
+    so_file = my_folder / (
+        "my_module" + sysconfig.get_config_var("EXT_SUFFIX")
+    )
+    assert so_file.exists()
+    assert (my_folder / "my_module.c").exists()


### PR DESCRIPTION
**Change:**
 - Introduce ```compile_kernels``` method in all contexts.
 - On ContextCpu, kernels can be saved or loaded from shared-object files.