### PR TITLE
Patch pyopencl with sqrt and isnan functions

### DIFF
--- a/tests/notest_capi.py
+++ b/tests/notest_capi.py
@@ -27,7 +27,6 @@ def gen_classes():
 
 
 def test_gen_data_paths():
-
     Field, Multipole = gen_classes()
     Field_N = Multipole.field.ftype
 

--- a/tests/test_capi.py
+++ b/tests/test_capi.py
@@ -541,7 +541,6 @@ def test_getp1_dyn_length_dyn_type_string_array():
 
 def test_gpu_api():
     for ctx in xo.context.get_test_contexts():
-
         src_code = """
         /*gpufun*/
         void myfun(double x, double y,

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -145,7 +145,6 @@ def test_assign_full_struct(test_context):
 
 
 def test_preinit():
-
     import numpy as np
 
     class Rotation(xo.Struct):

--- a/xobjects/_patch_pyopencl_array.py
+++ b/xobjects/_patch_pyopencl_array.py
@@ -70,7 +70,6 @@ def _patch_pyopencl_array(cl, cla, ctx):
             return "C"
 
     def copy_non_cont(src, dest, custom_itemsize=None, skip_typecheck=False):
-
         assert src.shape == dest.shape
 
         # The case float -> complex just works (by using the src itemsize)

--- a/xobjects/_patch_pyopencl_array.py
+++ b/xobjects/_patch_pyopencl_array.py
@@ -190,3 +190,11 @@ def _patch_pyopencl_array(cl, cla, ctx):
 
     cla.Array.real = property(myreal)
     cla.Array.sum = mysum
+
+    # sqrt available in clmath, add it to cla, so we can use it in nplike_lib
+    from pyopencl.clmath import sqrt as clm_sqrt
+
+    cla.sqrt = clm_sqrt
+
+    # isnan is not available, but can be simulated easily
+    cla.isnan = lambda ary: (ary != ary)

--- a/xobjects/context.py
+++ b/xobjects/context.py
@@ -180,7 +180,6 @@ class XContext(ABC):
         extra_headers: Sequence[SourceType] = (),
         compile: bool = True,  # noqa
     ):
-
         """
         Adds user-defined kernels to the context. The kernel source
         code is provided as a string and/or in source files and must contain
@@ -311,7 +310,6 @@ class XBuffer(ABC):
         default_alignment=None,
         grow_step=None,
     ):
-
         if context is None:
             self.context = self._make_context()
         else:

--- a/xobjects/context_cpu.py
+++ b/xobjects/context_cpu.py
@@ -546,7 +546,6 @@ class ContextCpu(XContext):
 
     @property
     def kernels(self):
-
         """
         Dictionary containing all the kernels that have been imported to the context.
         The syntax ``context.kernels.mykernel`` can also be used.
@@ -748,7 +747,6 @@ class KernelCpu:
 
 class FFTCpu(object):
     def __init__(self, data, axes, threads=0):
-
         self.axes = axes
         self.threads = threads
 

--- a/xobjects/context_cupy.py
+++ b/xobjects/context_cupy.py
@@ -385,7 +385,6 @@ class ContextCupy(XContext):
         return LinkedArrayCupy
 
     def __init__(self, default_block_size=256, device=None):
-
         if device is not None:
             cupy.cuda.Device(device).use()
 
@@ -534,7 +533,6 @@ class ContextCupy(XContext):
 
     @property
     def kernels(self):
-
         """
         Dictionary containing all the kernels that have been imported to the context.
         The syntax ``context.kernels.mykernel`` can also be used.
@@ -610,7 +608,6 @@ class KernelCupy(object):
         block_size,
         context,
     ):
-
         self.function = function
         self.description = description
         self.block_size = block_size
@@ -664,7 +661,6 @@ class KernelCupy(object):
 
 class FFTCupy(object):
     def __init__(self, context, data, axes):
-
         self.context = context
         self.axes = axes
 

--- a/xobjects/context_pyopencl.py
+++ b/xobjects/context_pyopencl.py
@@ -102,7 +102,6 @@ class ContextPyopencl(XContext):
     def __init__(
         self, device=None, patch_pyopencl_array=True, minimum_alignment=None
     ):
-
         """
         Creates a Pyopencl Context object, that allows performing the computations
         on GPUs and CPUs through PyOpenCL.
@@ -226,7 +225,6 @@ class ContextPyopencl(XContext):
         return out_kernels
 
     def nparray_to_context_array(self, arr):
-
         """
         Copies a numpy array to the device memory.
         Args:
@@ -240,7 +238,6 @@ class ContextPyopencl(XContext):
         return dev_arr
 
     def nparray_from_context_array(self, dev_arr):
-
         """
         Copies an array to the device to a numpy array.
 
@@ -304,7 +301,6 @@ class ContextPyopencl(XContext):
 
     @property
     def kernels(self):
-
         """
         Dictionary containing all the kernels that have been imported to the context.
         The syntax ``context.kernels.mykernel`` can also be used.
@@ -441,7 +437,6 @@ class KernelPyopencl(object):
         context,
         wait_on_call=True,
     ):
-
         self.function = function
         self.description = description
         self.context = context
@@ -505,7 +500,6 @@ class KernelPyopencl(object):
 
 class FFTPyopencl(object):
     def __init__(self, context, data, axes, wait_on_call=True):
-
         self.context = context
         self.axes = axes
         self.wait_on_call = wait_on_call

--- a/xobjects/hybrid_class.py
+++ b/xobjects/hybrid_class.py
@@ -40,7 +40,6 @@ class _FieldOfDressed:
         if self.isnplikearray:
             self.__get__(container=container)[:] = value
         elif hasattr(value, "_xobject"):  # value is a dressed xobject
-
             # Copy xobject data from value inside self._xobject
             # (unless same memory area or Ref and same buffer,
             #  in the latter case reference mechanism is used)
@@ -113,7 +112,6 @@ def _build_xofields_dict(bases, data):
 
 class MetaHybridClass(type):
     def __new__(cls, name, bases, data):
-
         if "_xofields" not in data.keys() and any(
             map(lambda b: hasattr(b, "_XoStruct"), bases)
         ):
@@ -198,7 +196,6 @@ class MetaHybridClass(type):
 
 
 class HybridClass(metaclass=MetaHybridClass):
-
     _movable = True
 
     def move(self, _context=None, _buffer=None, _offset=None):
@@ -246,7 +243,6 @@ class HybridClass(metaclass=MetaHybridClass):
                 setattr(self, pyname, vv)
 
     def xoinitialize(self, _xobject=None, _kwargs_name_check=True, **kwargs):
-
         if _kwargs_name_check:
             for kk in kwargs.keys():
                 if kk.startswith("_"):

--- a/xobjects/linkedarray.py
+++ b/xobjects/linkedarray.py
@@ -5,7 +5,6 @@
 
 
 class BaseLinkedArray:
-
     container = None
     container_setitem_name = None
     mode = None

--- a/xobjects/ref.py
+++ b/xobjects/ref.py
@@ -17,6 +17,7 @@ NULLVALUE = -(2**63)
 NULLTYPE = -1
 NULLREF = np.array([NULLVALUE, NULLTYPE], dtype="int64")
 
+
 # Ref is a like a scalar
 class MetaRef(type):
     def __getitem__(cls, reftype):
@@ -24,11 +25,9 @@ class MetaRef(type):
 
 
 class Ref(metaclass=MetaRef):
-
     _has_refs = True
 
     def __init__(self, reftype):
-
         if hasattr(reftype, "_XoStruct"):
             self._reftype = reftype._XoStruct
         else:
@@ -48,7 +47,6 @@ class Ref(metaclass=MetaRef):
             return self._reftype._from_buffer(buffer, refoffset)
 
     def _to_buffer(self, buffer, offset, value, info=None):
-
         # Get/set content
         if value is None:
             refoffset = NULLVALUE  # NULL value

--- a/xobjects/specialize_source.py
+++ b/xobjects/specialize_source.py
@@ -7,7 +7,6 @@ import os
 
 
 def specialize_source(source, specialize_for, search_in_folders=[]):
-
     assert specialize_for in ["cpu_serial", "cpu_openmp", "opencl", "cuda"]
 
     source_lines = source.splitlines()

--- a/xobjects/struct.py
+++ b/xobjects/struct.py
@@ -466,7 +466,6 @@ class Struct(metaclass=MetaStruct):
         apply_to_source=(),
         save_source_as=None,
     ):
-
         if only_if_needed:
             all_found = True
             for kk in cls._kernels.keys():


### PR DESCRIPTION
## Description

This patches `pyopencl` with a couple of functions that are available on `numpy` already: `sqrt` and `isnan`.

Needed by https://github.com/xsuite/xpart/pull/61 to abstract some logic.


## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [x] I have tested also GPU contexts
