### PR TITLE
Allow for "overriding" HybridClasses

### DIFF
--- a/xobjects/context.py
+++ b/xobjects/context.py
@@ -56,11 +56,13 @@ def topological_sort(source):
     return result, has_cycle
 
 
-def sort_classes(classes):
+def sort_classes(classes: list):
+    """Sort classes in order of dependencies. The input is a list: in case of
+    multiple classes with the same name, the last one is used.
+    """
     cdict = {cls.__name__: cls for cls in classes}
     deps = {}
-    lst = list(classes)
-    for cls in lst:
+    for cls in classes:
         cldeps = []
         cllist = []
         if hasattr(cls, "_get_inner_types"):
@@ -70,13 +72,13 @@ def sort_classes(classes):
         for cl in cllist:
             if not cl.__name__ in cdict:
                 cdict[cl.__name__] = cl
-                lst.append(cl)
+                classes.append(cl)
             cldeps.append(cl.__name__)
         deps[cls.__name__] = cldeps
-    lst, has_cycle = topological_sort(deps)
+    classes, has_cycle = topological_sort(deps)
     if has_cycle:
         raise ValueError("Class dependencies have cycles")
-    return [cdict[cn] for cn in lst if hasattr(cdict[cn], "_gen_c_api")]
+    return [cdict[cn] for cn in classes if hasattr(cdict[cn], "_gen_c_api")]
 
 
 def sources_from_classes(classes):

--- a/xobjects/context_cpu.py
+++ b/xobjects/context_cpu.py
@@ -260,8 +260,8 @@ class ContextCpu(XContext):
         module_name = module_name or str(uuid.uuid4().hex)
         containing_dir = containing_dir
 
-        classes = classes_from_kernels(kernel_descriptions)
-        classes.update(extra_classes)
+        classes = list(classes_from_kernels(kernel_descriptions))
+        classes += list(extra_classes)
         classes = sort_classes(classes)
 
         source, specialized_source = self._build_sources(

--- a/xobjects/context_cpu.py
+++ b/xobjects/context_cpu.py
@@ -262,6 +262,8 @@ class ContextCpu(XContext):
 
         classes = list(classes_from_kernels(kernel_descriptions))
         classes += list(extra_classes)
+        # classes = classes_from_kernels(kernel_descriptions)
+        # classes.update(extra_classes)
         classes = sort_classes(classes)
 
         source, specialized_source = self._build_sources(

--- a/xobjects/context_cpu.py
+++ b/xobjects/context_cpu.py
@@ -262,8 +262,6 @@ class ContextCpu(XContext):
 
         classes = list(classes_from_kernels(kernel_descriptions))
         classes += list(extra_classes)
-        # classes = classes_from_kernels(kernel_descriptions)
-        # classes.update(extra_classes)
         classes = sort_classes(classes)
 
         source, specialized_source = self._build_sources(

--- a/xobjects/context_cupy.py
+++ b/xobjects/context_cupy.py
@@ -414,8 +414,8 @@ class ContextCupy(XContext):
         if not compile:
             raise NotImplementedError("compile=False available only on CPU.")
 
-        classes = classes_from_kernels(kernel_descriptions)
-        classes.update(extra_classes)
+        classes = list(classes_from_kernels(kernel_descriptions))
+        classes += list(extra_classes)
         classes = sort_classes(classes)
         cls_sources = sources_from_classes(classes)
 

--- a/xobjects/context_pyopencl.py
+++ b/xobjects/context_pyopencl.py
@@ -188,8 +188,8 @@ class ContextPyopencl(XContext):
         if not compile:
             raise NotImplementedError("compile=False available only on CPU.")
 
-        classes = classes_from_kernels(kernel_descriptions)
-        classes.update(extra_classes)
+        classes = list(classes_from_kernels(kernel_descriptions))
+        classes += list(extra_classes)
         classes = sort_classes(classes)
         cls_sources = sources_from_classes(classes)
 

--- a/xobjects/hybrid_class.py
+++ b/xobjects/hybrid_class.py
@@ -118,7 +118,7 @@ class MetaHybridClass(type):
             # No action, use _XoStruct from base class (used to build PyHEADTAIL interface)
             return type.__new__(cls, name, bases, data)
 
-        _XoStruct_name = data.get('_cname', name + "Data")
+        _XoStruct_name = data.get("_cname", name + "Data")
 
         # Take xofields from data['_xofields'] or from bases
         xofields = _build_xofields_dict(bases, data)

--- a/xobjects/hybrid_class.py
+++ b/xobjects/hybrid_class.py
@@ -118,7 +118,7 @@ class MetaHybridClass(type):
             # No action, use _XoStruct from base class (used to build PyHEADTAIL interface)
             return type.__new__(cls, name, bases, data)
 
-        _XoStruct_name = name + "Data"
+        _XoStruct_name = data.get('_cname', name + "Data")
 
         # Take xofields from data['_xofields'] or from bases
         xofields = _build_xofields_dict(bases, data)

--- a/xobjects/struct.py
+++ b/xobjects/struct.py
@@ -485,8 +485,11 @@ class Struct(metaclass=MetaStruct):
         )
 
     def compile_kernels(
-        self, only_if_needed=False, apply_to_source=(), save_source_as=None,
-            extra_classes=(),
+        self,
+        only_if_needed=False,
+        apply_to_source=(),
+        save_source_as=None,
+        extra_classes=(),
     ):
         self.compile_class_kernels(
             context=self._context,

--- a/xobjects/struct.py
+++ b/xobjects/struct.py
@@ -465,6 +465,7 @@ class Struct(metaclass=MetaStruct):
         only_if_needed=False,
         apply_to_source=(),
         save_source_as=None,
+        extra_classes=(),
     ):
         if only_if_needed:
             all_found = True
@@ -478,19 +479,21 @@ class Struct(metaclass=MetaStruct):
         context.add_kernels(
             sources=[],
             kernels=cls._kernels,
-            extra_classes=[cls],
+            extra_classes=[cls] + list(extra_classes),
             apply_to_source=apply_to_source,
             save_source_as=save_source_as,
         )
 
     def compile_kernels(
-        self, only_if_needed=False, apply_to_source=(), save_source_as=None
+        self, only_if_needed=False, apply_to_source=(), save_source_as=None,
+            extra_classes=(),
     ):
         self.compile_class_kernels(
             context=self._context,
             only_if_needed=only_if_needed,
             apply_to_source=apply_to_source,
             save_source_as=save_source_as,
+            extra_classes=extra_classes,
         )
 
 


### PR DESCRIPTION
## Description

This introduces a mechanism that can allow to override HybridClasses by:

- letting the user change the name of the underlying XoStruct
- taking the "newer" XoStruct in sort_classes if two are provided

This is useful for defining multiple implementations of Particles class. The base specifies the interface xobject that all Particles need to conform to. These can then be overriden to add more fields or custom C methods.

Needed for xsuite/xpart#72.

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [ ] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [x] I have tested also GPU contexts
