### PR TITLE
Allow for "overriding" HybridClasses (without "minitracker")

### DIFF
--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -189,7 +189,7 @@ def test_kernels_save_files(tmp_path):
     )
     test_context.kernels.update(kernels)
 
-    assert kernels["myfun"].function(3, 4) == 12
+    assert test_context.kernels.myfun(x=3, y=4) == 12
 
     assert my_folder.exists()
     so_file = my_folder / (

--- a/xobjects/context.py
+++ b/xobjects/context.py
@@ -200,7 +200,7 @@ class KernelDispatcher:
         return self._kernels[(self._name, tuple(classes))](**kwargs)
 
     def set_n_threads(self, n_threads):
-        for name, kernel in self._kernels.items():
+        for (name, _), kernel in self._kernels.items():
             if name == self._name:
                 kernel.description.n_threads = n_threads
 

--- a/xobjects/context.py
+++ b/xobjects/context.py
@@ -158,6 +158,7 @@ class KernelDict(dict):
     KernelDispatcher object, which dynamically dispatches the kernel call to
     the correct kernel based on the types of the arguments.
     """
+
     def __getitem__(self, item):
         if isinstance(item, str):
             return KernelDispatcher(item, self)
@@ -172,13 +173,16 @@ class KernelDispatcher:
     Dispatches a kernel call to the correct kernel based on the types of the
     arguments.
     """
+
     def __init__(self, kernel_name, kernels):
         self._kernels = kernels
         self._name = kernel_name
 
     def __call__(self, *args, **kwargs):
         if args:
-            raise ValueError("Kernels can only be called with named arguments.")
+            raise ValueError(
+                "Kernels can only be called with named arguments."
+            )
 
         classes = []
         for arg in kwargs.values():
@@ -590,9 +594,12 @@ class Kernel:
         return classes
 
     def get_overridable_classes(self):
-        return [cls for cls in self.get_classes()
-                if hasattr(cls, '_DressingClass') and
-                cls._DressingClass._overridable]
+        return [
+            cls
+            for cls in self.get_classes()
+            if hasattr(cls, "_DressingClass")
+            and cls._DressingClass._overridable
+        ]
 
 
 class Source:

--- a/xobjects/context.py
+++ b/xobjects/context.py
@@ -56,11 +56,13 @@ def topological_sort(source):
     return result, has_cycle
 
 
-def sort_classes(classes):
+def sort_classes(classes: list):
+    """Sort classes in order of dependencies. The input is a list: in case of
+    multiple classes with the same name, the last one is used.
+    """
     cdict = {cls.__name__: cls for cls in classes}
     deps = {}
-    lst = list(classes)
-    for cls in lst:
+    for cls in classes:
         cldeps = []
         cllist = []
         if hasattr(cls, "_get_inner_types"):
@@ -70,13 +72,13 @@ def sort_classes(classes):
         for cl in cllist:
             if not cl.__name__ in cdict:
                 cdict[cl.__name__] = cl
-                lst.append(cl)
+                classes.append(cl)
             cldeps.append(cl.__name__)
         deps[cls.__name__] = cldeps
-    lst, has_cycle = topological_sort(deps)
+    classes, has_cycle = topological_sort(deps)
     if has_cycle:
         raise ValueError("Class dependencies have cycles")
-    return [cdict[cn] for cn in lst if hasattr(cdict[cn], "_gen_c_api")]
+    return [cdict[cn] for cn in classes if hasattr(cdict[cn], "_gen_c_api")]
 
 
 def sources_from_classes(classes):

--- a/xobjects/context.py
+++ b/xobjects/context.py
@@ -6,6 +6,7 @@
 import logging
 import os
 import weakref
+import xobjects as xo
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from pathlib import Path
@@ -179,13 +180,12 @@ class KernelDispatcher:
         if args:
             raise ValueError("Kernels can only be called with named arguments.")
 
-        from . import HybridClass, Struct
         classes = []
         for arg in kwargs.values():
-            if isinstance(arg, HybridClass):
+            if isinstance(arg, xo.HybridClass):
                 overridable = arg._overridable
                 arg_cls = arg._XoStruct
-            elif isinstance(arg, Struct):
+            elif isinstance(arg, xo.Struct):
                 arg_cls = type(arg)
                 try:
                     overridable = arg_cls._DressingClass._overridable

--- a/xobjects/context_cpu.py
+++ b/xobjects/context_cpu.py
@@ -260,8 +260,8 @@ class ContextCpu(XContext):
         module_name = module_name or str(uuid.uuid4().hex)
         containing_dir = containing_dir
 
-        classes = classes_from_kernels(kernel_descriptions)
-        classes.update(extra_classes)
+        classes = list(classes_from_kernels(kernel_descriptions))
+        classes += list(extra_classes)
         classes = sort_classes(classes)
 
         source, specialized_source = self._build_sources(

--- a/xobjects/context_cpu.py
+++ b/xobjects/context_cpu.py
@@ -262,6 +262,8 @@ class ContextCpu(XContext):
 
         classes = list(classes_from_kernels(kernel_descriptions))
         classes += list(extra_classes)
+        # classes = classes_from_kernels(kernel_descriptions)
+        # classes.update(extra_classes)
         classes = sort_classes(classes)
 
         source, specialized_source = self._build_sources(

--- a/xobjects/context_cpu.py
+++ b/xobjects/context_cpu.py
@@ -262,8 +262,6 @@ class ContextCpu(XContext):
 
         classes = list(classes_from_kernels(kernel_descriptions))
         classes += list(extra_classes)
-        # classes = classes_from_kernels(kernel_descriptions)
-        # classes.update(extra_classes)
         classes = sort_classes(classes)
 
         source, specialized_source = self._build_sources(

--- a/xobjects/context_cpu.py
+++ b/xobjects/context_cpu.py
@@ -264,6 +264,12 @@ class ContextCpu(XContext):
         classes += list(extra_classes)
         classes = sort_classes(classes)
 
+        # Update the kernel descriptions with the overriden classes
+        cls_for_name = {cls.__name__: cls for cls in classes}
+        for kernel_name, kernel in kernel_descriptions.items():
+            for arg in kernel.args:
+                arg.atype = cls_for_name.get(arg.atype.__name__, arg.atype)
+
         source, specialized_source = self._build_sources(
             sources=sources,
             classes=classes,

--- a/xobjects/context_cpu.py
+++ b/xobjects/context_cpu.py
@@ -9,7 +9,7 @@ import os
 import sysconfig
 import uuid
 from pathlib import Path
-from typing import Callable, Dict, List, Sequence, Tuple
+from typing import Any, Callable, Dict, List, Sequence, Tuple
 
 import numpy as np
 
@@ -254,7 +254,7 @@ class ContextCpu(XContext):
         extra_classes=(),
         extra_headers=(),
         compile=True,  # noqa
-    ) -> Dict[str, "KernelCpu"]:
+    ) -> dict[str, 'KernelCpu']:
         # Determine names and paths
         clean_up_so = not module_name
         module_name = module_name or str(uuid.uuid4().hex)
@@ -327,7 +327,11 @@ class ContextCpu(XContext):
             # TODO: find better implementation?
             out_kernels[pyname].description.pyname = pyname
 
-        return out_kernels
+        kernels_with_classes = {
+            (name, tuple(kernel.description.get_classes())): kernel
+            for name, kernel in out_kernels.items()
+        }
+        return kernels_with_classes
 
     def kernels_from_file(
         self,

--- a/xobjects/context_cpu.py
+++ b/xobjects/context_cpu.py
@@ -254,7 +254,7 @@ class ContextCpu(XContext):
         extra_classes=(),
         extra_headers=(),
         compile=True,  # noqa
-    ) -> dict[str, 'KernelCpu']:
+    ) -> dict[str, "KernelCpu"]:
         # Determine names and paths
         clean_up_so = not module_name
         module_name = module_name or str(uuid.uuid4().hex)

--- a/xobjects/context_cpu.py
+++ b/xobjects/context_cpu.py
@@ -328,7 +328,7 @@ class ContextCpu(XContext):
             out_kernels[pyname].description.pyname = pyname
 
         kernels_with_classes = {
-            (name, tuple(kernel.description.get_classes())): kernel
+            (name, tuple(kernel.description.get_overridable_classes())): kernel
             for name, kernel in out_kernels.items()
         }
         return kernels_with_classes

--- a/xobjects/context_cupy.py
+++ b/xobjects/context_cupy.py
@@ -417,6 +417,13 @@ class ContextCupy(XContext):
         classes = list(classes_from_kernels(kernel_descriptions))
         classes += list(extra_classes)
         classes = sort_classes(classes)
+
+        # Update the kernel descriptions with the overriden classes
+        cls_for_name = {cls.__name__: cls for cls in classes}
+        for kernel_name, kernel in kernel_descriptions.items():
+            for arg in kernel.args:
+                arg.atype = cls_for_name.get(arg.atype.__name__, arg.atype)
+
         cls_sources = sources_from_classes(classes)
 
         headers = cudaheader + list(extra_headers)

--- a/xobjects/context_cupy.py
+++ b/xobjects/context_cupy.py
@@ -455,7 +455,11 @@ class ContextCupy(XContext):
             out_kernels[pyname].source = source
             out_kernels[pyname].specialized_source = specialized_source
 
-        return out_kernels
+        kernels_with_classes = {
+            (name, tuple(kernel.description.get_classes())): kernel
+            for name, kernel in out_kernels.items()
+        }
+        return kernels_with_classes
 
     def nparray_to_context_array(self, arr):
         """

--- a/xobjects/context_cupy.py
+++ b/xobjects/context_cupy.py
@@ -414,8 +414,8 @@ class ContextCupy(XContext):
         if not compile:
             raise NotImplementedError("compile=False available only on CPU.")
 
-        classes = classes_from_kernels(kernel_descriptions)
-        classes.update(extra_classes)
+        classes = list(classes_from_kernels(kernel_descriptions))
+        classes += list(extra_classes)
         classes = sort_classes(classes)
         cls_sources = sources_from_classes(classes)
 

--- a/xobjects/context_cupy.py
+++ b/xobjects/context_cupy.py
@@ -456,7 +456,7 @@ class ContextCupy(XContext):
             out_kernels[pyname].specialized_source = specialized_source
 
         kernels_with_classes = {
-            (name, tuple(kernel.description.get_classes())): kernel
+            (name, tuple(kernel.description.get_overridable_classes())): kernel
             for name, kernel in out_kernels.items()
         }
         return kernels_with_classes

--- a/xobjects/context_pyopencl.py
+++ b/xobjects/context_pyopencl.py
@@ -227,7 +227,11 @@ class ContextPyopencl(XContext):
             out_kernels[pyname].source = source
             out_kernels[pyname].specialized_source = specialized_source
 
-        return out_kernels
+        kernels_with_classes = {
+            (name, tuple(kernel.description.get_classes())): kernel
+            for name, kernel in out_kernels.items()
+        }
+        return kernels_with_classes
 
     def nparray_to_context_array(self, arr):
         """

--- a/xobjects/context_pyopencl.py
+++ b/xobjects/context_pyopencl.py
@@ -191,6 +191,13 @@ class ContextPyopencl(XContext):
         classes = list(classes_from_kernels(kernel_descriptions))
         classes += list(extra_classes)
         classes = sort_classes(classes)
+
+        # Update the kernel descriptions with the overriden classes
+        cls_for_name = {cls.__name__: cls for cls in classes}
+        for kernel_name, kernel in kernel_descriptions.items():
+            for arg in kernel.args:
+                arg.atype = cls_for_name.get(arg.atype.__name__, arg.atype)
+
         cls_sources = sources_from_classes(classes)
 
         headers = openclheader + list(extra_headers)

--- a/xobjects/context_pyopencl.py
+++ b/xobjects/context_pyopencl.py
@@ -188,8 +188,8 @@ class ContextPyopencl(XContext):
         if not compile:
             raise NotImplementedError("compile=False available only on CPU.")
 
-        classes = classes_from_kernels(kernel_descriptions)
-        classes.update(extra_classes)
+        classes = list(classes_from_kernels(kernel_descriptions))
+        classes += list(extra_classes)
         classes = sort_classes(classes)
         cls_sources = sources_from_classes(classes)
 

--- a/xobjects/context_pyopencl.py
+++ b/xobjects/context_pyopencl.py
@@ -228,7 +228,7 @@ class ContextPyopencl(XContext):
             out_kernels[pyname].specialized_source = specialized_source
 
         kernels_with_classes = {
-            (name, tuple(kernel.description.get_classes())): kernel
+            (name, tuple(kernel.description.get_overridable_classes())): kernel
             for name, kernel in out_kernels.items()
         }
         return kernels_with_classes

--- a/xobjects/hybrid_class.py
+++ b/xobjects/hybrid_class.py
@@ -118,7 +118,7 @@ class MetaHybridClass(type):
             # No action, use _XoStruct from base class (used to build PyHEADTAIL interface)
             return type.__new__(cls, name, bases, data)
 
-        _XoStruct_name = data.get('_cname', name + "Data")
+        _XoStruct_name = data.get("_cname", name + "Data")
 
         # Take xofields from data['_xofields'] or from bases
         xofields = _build_xofields_dict(bases, data)

--- a/xobjects/hybrid_class.py
+++ b/xobjects/hybrid_class.py
@@ -118,7 +118,7 @@ class MetaHybridClass(type):
             # No action, use _XoStruct from base class (used to build PyHEADTAIL interface)
             return type.__new__(cls, name, bases, data)
 
-        _XoStruct_name = name + "Data"
+        _XoStruct_name = data.get('_cname', name + "Data")
 
         # Take xofields from data['_xofields'] or from bases
         xofields = _build_xofields_dict(bases, data)

--- a/xobjects/hybrid_class.py
+++ b/xobjects/hybrid_class.py
@@ -197,6 +197,7 @@ class MetaHybridClass(type):
 
 class HybridClass(metaclass=MetaHybridClass):
     _movable = True
+    _overridable = True
 
     def move(self, _context=None, _buffer=None, _offset=None):
         if not self._movable:

--- a/xobjects/struct.py
+++ b/xobjects/struct.py
@@ -485,8 +485,11 @@ class Struct(metaclass=MetaStruct):
         )
 
     def compile_kernels(
-        self, only_if_needed=False, apply_to_source=(), save_source_as=None,
-            extra_classes=(),
+        self,
+        only_if_needed=False,
+        apply_to_source=(),
+        save_source_as=None,
+        extra_classes=(),
     ):
         self.compile_class_kernels(
             context=self._context,

--- a/xobjects/struct.py
+++ b/xobjects/struct.py
@@ -465,6 +465,7 @@ class Struct(metaclass=MetaStruct):
         only_if_needed=False,
         apply_to_source=(),
         save_source_as=None,
+        extra_classes=(),
     ):
         if only_if_needed:
             all_found = True
@@ -478,19 +479,21 @@ class Struct(metaclass=MetaStruct):
         context.add_kernels(
             sources=[],
             kernels=cls._kernels,
-            extra_classes=[cls],
+            extra_classes=[cls] + list(extra_classes),
             apply_to_source=apply_to_source,
             save_source_as=save_source_as,
         )
 
     def compile_kernels(
-        self, only_if_needed=False, apply_to_source=(), save_source_as=None
+        self, only_if_needed=False, apply_to_source=(), save_source_as=None,
+            extra_classes=(),
     ):
         self.compile_class_kernels(
             context=self._context,
             only_if_needed=only_if_needed,
             apply_to_source=apply_to_source,
             save_source_as=save_source_as,
+            extra_classes=extra_classes,
         )
 
 


### PR DESCRIPTION
## Description

This introduces a mechanism that can allow to override HybridClasses by:

- letting the user change the name of the underlying XoStruct
- taking the "newer" XoStruct in sort_classes if two are provided

This is useful for defining multiple implementations of Particles class. The base specifies the interface xobject that all Particles need to conform to. These can then be overriden to add more fields or custom C methods.

Replaces #93.

Needed for xsuite/xpart#73.

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [ ] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [x] I have tested also GPU contexts
