### PR TITLE
Release/v0.1.33

### DIFF
--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -189,7 +189,7 @@ def test_kernels_save_files(tmp_path):
     )
     test_context.kernels.update(kernels)
 
-    assert kernels["myfun"].function(3, 4) == 12
+    assert test_context.kernels.myfun(x=3, y=4) == 12
 
     assert my_folder.exists()
     so_file = my_folder / (

--- a/xobjects/context_cupy.py
+++ b/xobjects/context_cupy.py
@@ -414,9 +414,16 @@ class ContextCupy(XContext):
         if not compile:
             raise NotImplementedError("compile=False available only on CPU.")
 
-        classes = classes_from_kernels(kernel_descriptions)
-        classes.update(extra_classes)
+        classes = list(classes_from_kernels(kernel_descriptions))
+        classes += list(extra_classes)
         classes = sort_classes(classes)
+
+        # Update the kernel descriptions with the overriden classes
+        cls_for_name = {cls.__name__: cls for cls in classes}
+        for kernel_name, kernel in kernel_descriptions.items():
+            for arg in kernel.args:
+                arg.atype = cls_for_name.get(arg.atype.__name__, arg.atype)
+
         cls_sources = sources_from_classes(classes)
 
         headers = cudaheader + list(extra_headers)
@@ -455,7 +462,11 @@ class ContextCupy(XContext):
             out_kernels[pyname].source = source
             out_kernels[pyname].specialized_source = specialized_source
 
-        return out_kernels
+        kernels_with_classes = {
+            (name, tuple(kernel.description.get_overridable_classes())): kernel
+            for name, kernel in out_kernels.items()
+        }
+        return kernels_with_classes
 
     def nparray_to_context_array(self, arr):
         """

--- a/xobjects/hybrid_class.py
+++ b/xobjects/hybrid_class.py
@@ -118,7 +118,7 @@ class MetaHybridClass(type):
             # No action, use _XoStruct from base class (used to build PyHEADTAIL interface)
             return type.__new__(cls, name, bases, data)
 
-        _XoStruct_name = name + "Data"
+        _XoStruct_name = data.get("_cname", name + "Data")
 
         # Take xofields from data['_xofields'] or from bases
         xofields = _build_xofields_dict(bases, data)
@@ -197,6 +197,7 @@ class MetaHybridClass(type):
 
 class HybridClass(metaclass=MetaHybridClass):
     _movable = True
+    _overridable = True
 
     def move(self, _context=None, _buffer=None, _offset=None):
         if not self._movable:

--- a/xobjects/struct.py
+++ b/xobjects/struct.py
@@ -465,6 +465,7 @@ class Struct(metaclass=MetaStruct):
         only_if_needed=False,
         apply_to_source=(),
         save_source_as=None,
+        extra_classes=(),
     ):
         if only_if_needed:
             all_found = True
@@ -478,19 +479,24 @@ class Struct(metaclass=MetaStruct):
         context.add_kernels(
             sources=[],
             kernels=cls._kernels,
-            extra_classes=[cls],
+            extra_classes=[cls] + list(extra_classes),
             apply_to_source=apply_to_source,
             save_source_as=save_source_as,
         )
 
     def compile_kernels(
-        self, only_if_needed=False, apply_to_source=(), save_source_as=None
+        self,
+        only_if_needed=False,
+        apply_to_source=(),
+        save_source_as=None,
+        extra_classes=(),
     ):
         self.compile_class_kernels(
             context=self._context,
             only_if_needed=only_if_needed,
             apply_to_source=apply_to_source,
             save_source_as=save_source_as,
+            extra_classes=extra_classes,
         )
 
 


### PR DESCRIPTION
**Changes:**

- Allow for overriding hybrid classes. Add a new field `_cname` which allows to manually specify the name of the generated XoStruct. Change `context.sort_classes` such that duplicated classes appearing later in the list override the ones that appear earlier. Associate kernels in their contexts not only with their name but also the overridable classes that they were built with.