### PR TITLE
Correct type annotations, use typing supported in Python 3.7

### DIFF
--- a/xobjects/context.py
+++ b/xobjects/context.py
@@ -10,7 +10,16 @@ import xobjects as xo
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from pathlib import Path
-from typing import Dict, List, NamedTuple, Optional, Sequence, Type, Union
+from typing import (
+    Dict,
+    List,
+    NamedTuple,
+    Optional,
+    Sequence,
+    Type,
+    Tuple,
+    Union,
+)
 
 """
 
@@ -346,7 +355,7 @@ class XContext(ABC):
         extra_classes: Sequence[Type],
         extra_headers: Sequence[SourceType],
         compile: bool,
-    ) -> Dict[str, KernelType]:
+    ) -> Dict[Tuple[str, tuple], KernelType]:
         pass
 
     @abstractmethod

--- a/xobjects/context_cpu.py
+++ b/xobjects/context_cpu.py
@@ -9,7 +9,7 @@ import os
 import sysconfig
 import uuid
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Sequence, Tuple
+from typing import Callable, Dict, List, Sequence, Tuple
 
 import numpy as np
 
@@ -254,7 +254,7 @@ class ContextCpu(XContext):
         extra_classes=(),
         extra_headers=(),
         compile=True,  # noqa
-    ) -> dict[str, "KernelCpu"]:
+    ) -> Dict[Tuple[str, tuple], "KernelCpu"]:
         # Determine names and paths
         clean_up_so = not module_name
         module_name = module_name or str(uuid.uuid4().hex)

--- a/xobjects/context_cupy.py
+++ b/xobjects/context_cupy.py
@@ -4,12 +4,11 @@
 # ########################################### #
 
 import logging
-from typing import Dict, List
+from typing import Dict, List, Tuple
 
 import numpy as np
 
 from .context import (
-    KernelType,
     ModuleNotAvailable,
     SourceType,
     XBuffer,
@@ -410,7 +409,7 @@ class ContextCupy(XContext):
         extra_classes=(),
         extra_headers=(),
         compile=True,  # noqa
-    ) -> Dict[str, KernelType]:
+    ) -> Dict[Tuple[str, tuple], "KernelCupy"]:
         if not compile:
             raise NotImplementedError("compile=False available only on CPU.")
 

--- a/xobjects/context_pyopencl.py
+++ b/xobjects/context_pyopencl.py
@@ -6,7 +6,7 @@
 import logging
 
 import numpy as np
-from typing import List
+from typing import List, Dict, Tuple
 
 from .context import (
     ModuleNotAvailable,
@@ -184,7 +184,7 @@ class ContextPyopencl(XContext):
         extra_classes=(),
         extra_headers=(),
         compile=True,  # noqa
-    ):
+    ) -> Dict[Tuple[str, tuple], "KernelPyopencl"]:
         if not compile:
             raise NotImplementedError("compile=False available only on CPU.")
 


### PR DESCRIPTION
## Description

Don't use generic type hints, which are not supported in Python 3.6. Fix some that were not correct.

Closes xsuite/xsuite#319.

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
