### PR TITLE
bugfix: unnecessary recompilations in `HybridClass.compile_class_kernels`

### DIFF
--- a/xobjects/__init__.py
+++ b/xobjects/__init__.py
@@ -37,4 +37,3 @@ from .linkedarray import BypassLinked
 from .general import _print
 
 from ._version import __version__
-

--- a/xobjects/context_cpu.py
+++ b/xobjects/context_cpu.py
@@ -376,7 +376,7 @@ class ContextCpu(XContext):
         ffi_interface.cdef(cdefs)
 
         if self._compile_kernels_info:
-            _print('Compiling ContextCpu kernels...')
+            _print("Compiling ContextCpu kernels...")
 
         for pyname, kernel in kernel_descriptions.items():
             if pyname not in cdefs:  # check if kernel not already declared
@@ -413,10 +413,11 @@ class ContextCpu(XContext):
             so_file = str(
                 _so_for_module_name(module_name, containing_dir).absolute()
             )
-            output_file = ffi_interface.compile(target=so_file,
-                                                verbose=self._cffi_verbose)
+            output_file = ffi_interface.compile(
+                target=so_file, verbose=self._cffi_verbose
+            )
             if self._compile_kernels_info:
-                _print('Done compiling ContextCpu kernels.')
+                _print("Done compiling ContextCpu kernels.")
             return Path(output_file)
         finally:
             # Clean temp files
@@ -428,8 +429,6 @@ class ContextCpu(XContext):
             for ff in files_to_remove:
                 if os.path.exists(ff):
                     os.remove(ff)
-
-
 
     def _build_sources(
         self,

--- a/xobjects/general.py
+++ b/xobjects/general.py
@@ -1,8 +1,9 @@
-class Print():
+class Print:
     suppress = False
 
     def __call__(self, *args, **kwargs):
         if not self.suppress:
             print(*args, **kwargs)
+
 
 _print = Print()

--- a/xobjects/struct.py
+++ b/xobjects/struct.py
@@ -469,8 +469,9 @@ class Struct(metaclass=MetaStruct):
     ):
         if only_if_needed:
             all_found = True
-            for kk in cls._kernels.keys():
-                if kk not in context.kernels.keys():
+            for kk, kernel_description in cls._kernels.items():
+                classes = tuple(kernel_description.get_overridable_classes())
+                if (kk, classes) not in context.kernels.keys():
                     all_found = False
                     break
             if all_found:


### PR DESCRIPTION
## Description

Fixes a bug where the flag `only_if_needed` in `HybridClass.compile_class_kernels` was essentially ignored, as the code of the method was not adapted to the recent changes in #96; added a test to for tracking this regression.

Closes xsuite/xsuite#320

## Checklist

Mandatory: 

- [x] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
