### PR TITLE
Add support for OpenMP

### DIFF
--- a/xobjects/context.py
+++ b/xobjects/context.py
@@ -677,7 +677,7 @@ def get_test_contexts():
     ctxstr = os.environ.get("XOBJECTS_TEST_CONTEXTS")
     if ctxstr is None:
         yield xo.ContextCpu()
-        # yield xo.ContextCpu(omp_num_threads=2)
+        yield xo.ContextCpu(omp_num_threads="auto")
         if xo.ContextCupy in xo.context.available:
             yield xo.ContextCupy()
         if xo.ContextPyopencl in xo.context.available:

--- a/xobjects/context.py
+++ b/xobjects/context.py
@@ -652,6 +652,8 @@ def get_context_from_string(ctxstr):
     if ctxtype == "ContextCpu":
         if len(option) == 0:
             return xo.ContextCpu()
+        elif option[0] == "auto":
+            return xo.ContextCpu(omp_num_threads="auto")
         else:
             return xo.ContextCpu(omp_num_threads=int(option[0]))
     elif ctxtype == "ContextCupy":
@@ -682,7 +684,7 @@ def get_test_contexts():
             yield xo.ContextPyopencl()
     elif ctxstr == "all":
         yield xo.ContextCpu()
-        yield xo.ContextCpu(omp_num_threads=2)
+        yield xo.ContextCpu(omp_num_threads="auto")
         if xo.ContextCupy in xo.context.available:
             yield xo.ContextCupy()
         if xo.ContextPyopencl in xo.context.available:
@@ -705,6 +707,7 @@ def get_user_context():
        ContextPyopencl      -> ContextPyopencl()
        ContextCpu           -> ContextCpu()
        ContextCpu:2         -> ContextCpu(omp_num_threads=2)
+       ContextCpu:auto      -> ContextCpu(omp_num_threads='auto')
        ContextCupy:0        -> ContextCupy(device=0)
     """
     import os

--- a/xobjects/context.py
+++ b/xobjects/context.py
@@ -233,6 +233,9 @@ class XContext(ABC):
         self._kernels = KernelDict()
         self._buffers = []
 
+    def __str__(self):
+        return type(self).__name__
+
     def new_buffer(self, capacity=1048576):
         buf = self._make_buffer(capacity=capacity)
         self.buffers.append(weakref.finalize(buf, log.debug, "free buf"))

--- a/xobjects/context_cpu.py
+++ b/xobjects/context_cpu.py
@@ -136,11 +136,6 @@ class ContextCpu(XContext):
         super().__init__()
         self.omp_num_threads = omp_num_threads
 
-        if self.omp_num_threads > 1:
-            raise NotImplementedError(
-                "OpenMP parallelization not yet supported!"
-            )
-
     def _make_buffer(self, capacity):
         return BufferNumpy(capacity=capacity, context=self)
 
@@ -482,7 +477,6 @@ class ContextCpu(XContext):
         spec.loader.exec_module(module)
 
         if self.omp_num_threads > 0:
-            raise NotImplementedError("OpenMP not supported for now!")
             self.omp_set_num_threads = module.lib.omp_set_num_threads
 
         return module

--- a/xobjects/context_cpu.py
+++ b/xobjects/context_cpu.py
@@ -136,6 +136,12 @@ class ContextCpu(XContext):
         super().__init__()
         self.omp_num_threads = omp_num_threads
 
+    def __str__(self):
+        if self.omp_num_threads == 0:
+            return super().__str__()
+        else:
+            return f"{type(self).__name__}:{self.omp_num_threads}"
+
     def _make_buffer(self, capacity):
         return BufferNumpy(capacity=capacity, context=self)
 

--- a/xobjects/test_helpers.py
+++ b/xobjects/test_helpers.py
@@ -21,9 +21,9 @@ def _for_all_test_contexts_excluding(
         excluding = (excluding,)
 
     test_context_names = tuple(
-        ctx_name
+        str(ctx)
         for ctx in get_test_contexts()
-        if (ctx_name := type(ctx).__name__) not in excluding
+        if type(ctx).__name__ not in excluding
     )
 
     @wraps(test_function)


### PR DESCRIPTION
## Description

This PR is part of the effort to enable OpenMP support in Xsuite. An xobjects context supporting OpenMP can be spawned with `ContextCPU(omp_num_threads=N)`, where `N` is a positive integer specyfing the number of threads to spawn, or a string `"auto"`, which will let OpenMP choose the most optimal number.

Closes xsuite/xsuite#15.

## Checklist

Mandatory: 

- [x] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
