### PR TITLE
Add link to a scipy-like lib in context CPU and Cupy

### DIFF
--- a/xobjects/context_cpu.py
+++ b/xobjects/context_cpu.py
@@ -14,6 +14,7 @@ from typing import Callable, Dict, List, Sequence, Tuple
 from .general import _print
 
 import numpy as np
+import scipy as sp
 
 from .context import (
     Kernel,
@@ -525,6 +526,16 @@ class ContextCpu(XContext):
         """
 
         return np
+
+    @property
+    def splike_lib(self):
+        """
+        Module containing all the scipy features. Numpy members should be accessed
+        through ``splike_lib`` to keep compatibility with the other contexts.
+
+        """
+
+        return sp
 
     def synchronize(self):
         """

--- a/xobjects/context_cupy.py
+++ b/xobjects/context_cupy.py
@@ -26,6 +26,11 @@ log = logging.getLogger(__name__)
 
 try:
     import cupy
+    import cupyx.scipy
+    import cupyx.scipy.interpolate
+    import cupyx.scipy.signal
+    import cupyx.scipy.special
+    import cupyx.scipy.stats
     from cupyx.scipy import fftpack as cufftp
 
     _enabled = True
@@ -499,6 +504,13 @@ class ContextCupy(XContext):
         Module containing all the numpy features supported by cupy.
         """
         return cupy
+
+    @property
+    def splike_lib(self):
+        """
+        Module containing all the scipy features supported by cupy.
+        """
+        return cupyx.scipy
 
     def synchronize(self):
         """

--- a/xobjects/context_pyopencl.py
+++ b/xobjects/context_pyopencl.py
@@ -273,6 +273,13 @@ class ContextPyopencl(XContext):
         """
         return cla
 
+    @property
+    def splike_lib(self):
+        """
+        Scipy features are not available through openCL
+        """
+        raise NotImplementedError
+
     def synchronize(self):
         """
         Ensures that all computations submitted to the context are completed.


### PR DESCRIPTION
## Description
Add link to a scipy-like lib in context CPU and Cupy following the implementation of the numpy-like lib

Closes # .

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [ ] All the tests are passing, including my new ones
- [ ] I described my changes in this PR description

Optional:

- [ ] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
