### PR TITLE
add a missing dependency on pytest-mock to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,6 @@ setup(
         "Source Code": "https://github.com/xsuite/xobjects",
     },
     extras_require={
-        "tests": ["pytest"],
+        "tests": ["pytest", "pytest-mock"],
     },
 )


### PR DESCRIPTION
## Description

Add a missing test dependency on `pytest-mock` to `setup.py`.

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
