### PR TITLE
Allow empty arrays on PyOpenCL

### DIFF
--- a/tests/test_array.py
+++ b/tests/test_array.py
@@ -301,3 +301,20 @@ def test_array_custom_strides(test_context):
     for i0, i1, i2 in np.ndindex(2, 3, 4):
         assert a_xo[i0, i1, i2] == j
         j += 1
+
+
+@for_all_test_contexts
+def test_zero_length_arrays(test_context):
+    dynamic_py = xo.Int64[:]([], _context=test_context)
+    assert len(dynamic_py) == 0
+
+    dynamic_np = xo.Int64[:](np.array([]), _context=test_context)
+    assert len(dynamic_np) == 0
+
+    fixed_py = xo.Int64[0]([], _context=test_context)
+    assert len(fixed_py) == 0
+    assert fixed_py._buffer.capacity == 0
+
+    fixed_np = xo.Int64[0](np.array([]), _context=test_context)
+    assert len(fixed_np) == 0
+    assert fixed_np._buffer.capacity == 0

--- a/xobjects/context_pyopencl.py
+++ b/xobjects/context_pyopencl.py
@@ -337,6 +337,8 @@ class BufferPyopencl(XBuffer):
         return ContextPyopencl()
 
     def _new_buffer(self, capacity):
+        if capacity == 0:
+            return None
         return cl.Buffer(
             self.context.context, cl.mem_flags.READ_WRITE, capacity
         )
@@ -372,6 +374,8 @@ class BufferPyopencl(XBuffer):
         self, offset: int, source: cl.Buffer, source_offset: int, nbytes: int
     ):
         """Copy data from native buffer into self.buffer starting from offset"""
+        if nbytes == 0:
+            return
         cl.enqueue_copy(
             self.context.queue,
             self.buffer,


### PR DESCRIPTION
## Description

This allows creating zero-length arrays (and objects) on the OpenCL context. On the other contexts this works already out of the box, but with CL this would cause errors (see the issue below for an example).

Fixes xsuite/xsuite#294

## Checklist

Mandatory: 

- [x] I have added tests to cover my changes
- [ ] All the tests are passing, including my new ones (in progress)
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [x] I have tested also GPU contexts
