### PR TITLE
To dict

### DIFF
--- a/xobjects/hybrid_class.py
+++ b/xobjects/hybrid_class.py
@@ -301,7 +301,13 @@ class HybridClass(metaclass=MetaHybridClass):
 
         if hasattr(obj, "_store_in_to_dict"):
             for nn in obj._store_in_to_dict:
-                out[nn] = getattr(obj, nn)
+                ww = getattr(obj, nn)
+                if hasattr(ww, "to_dict"):
+                    out[nn] = ww.to_dict()
+                elif hasattr(ww, "_to_dict"):
+                    out[nn] = ww._to_dict()
+                else:
+                    out[nn] = vv
 
         return out
 

--- a/xobjects/hybrid_class.py
+++ b/xobjects/hybrid_class.py
@@ -307,7 +307,7 @@ class HybridClass(metaclass=MetaHybridClass):
                 elif hasattr(ww, "_to_dict"):
                     out[nn] = ww._to_dict()
                 else:
-                    out[nn] = vv
+                    out[nn] = ww
 
         return out
 


### PR DESCRIPTION
## Description
<!-- Describe why you are making the changes you do
 and link the relevant issues below. -->

Very small fix: the to_dict() functionality in the HybridClass correctly cascades recursively in case one of its fields is a HybridClass itself (more correctly, if the field has a to_dict or _to_dict property). However, this functionality was not present in case the field was generated from the _store_in_to_dict property. This cascading is now added.

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [X] All the tests are passing, including my new ones
- [X] I described my changes in this PR description

Optional:

- [X] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
