### PR TITLE
Implemented a way to use prebuilt kernels at the level of the xo.Struct

### DIFF
--- a/xobjects/context.py
+++ b/xobjects/context.py
@@ -230,6 +230,7 @@ class ModuleNotAvailable(object):
 
 class XContext(ABC):
     minimum_alignment = 1
+    allow_prebuilt_kernels = False
 
     def __init__(self):
         self._kernels = KernelDict()

--- a/xobjects/context_cpu.py
+++ b/xobjects/context_cpu.py
@@ -19,7 +19,6 @@ import scipy as sp
 _forbid_compile = False
 
 from .context import (
-    Arg,
     Kernel,
     ModuleNotAvailable,
     SourceType,
@@ -146,6 +145,8 @@ class ContextCpu(XContext):
         """
         super().__init__()
         self.omp_num_threads = omp_num_threads
+        if omp_num_threads==0:
+            self.allow_prebuilt_kernels = True
 
     def __str__(self):
         if not self.openmp_enabled:
@@ -367,7 +368,6 @@ class ContextCpu(XContext):
             containing_dir=containing_dir,
         )
         out_kernels = {}
-        kernel_descriptions = _get_kernels_with_default_particles(kernel_descriptions)
         for pyname, kernel_desc in kernel_descriptions.items():
             classes = tuple(kernel_desc.get_overridable_classes())
             out_kernels[(pyname, classes)] = KernelCpu(
@@ -677,37 +677,6 @@ class BufferByteArray(XBuffer):
     def to_pointer_arg(self, offset, nbytes):
         """return data that can be used as argument in kernel"""
         return self.buffer[offset : offset + nbytes]
-
-
-def _get_kernels_with_default_particles(kernel_descriptions):
-    # prebuilt kernels only work with xp.Particles, however, at the time
-    # of compilation a lot of kernels use xp.ParticlesBase as it is not
-    # known yet which will be use.
-    import xpart as xp
-    new_descriptions = {}
-    for name, ker in kernel_descriptions.items():
-        new_args = []
-        for arg in ker.args:
-            new_arg = Arg(atype=arg.atype,
-                             pointer=arg.pointer,
-                             name=arg.name,
-                             const=arg.const,
-                             factory=arg.factory)
-            if getattr(new_arg.atype, '_DressingClass', None) == xp.ParticlesBase:
-                new_arg.atype = xp.Particles._XoStruct
-            new_args.append(new_arg)
-        if ker.ret is None:
-            new_ret = None
-        else:
-            new_ret = xo.Arg(atype=ker.ret.atype,
-                             pointer=ker.ret.pointer,
-                             name=ker.ret.name,
-                             const=ker.ret.const,
-                             factory=ker.ret.factory)
-            if getattr(new_ret.atype, '_DressingClass', None) == xp.ParticlesBase:
-                new_ret.atype = xp.Particles._XoStruct
-        new_descriptions[name] = Kernel(args=new_args, ret=new_ret, c_name=ker.c_name)
-    return new_descriptions
 
 
 class BufferNumpy(XBuffer):

--- a/xobjects/hybrid_class.py
+++ b/xobjects/hybrid_class.py
@@ -392,7 +392,7 @@ class PyMethod:
 
     def __call__(self, **kwargs):
         instance = self.element
-        context = instance.context
+        context = instance._context
 
         use_prebuilt_kernels = kwargs.pop('use_prebuilt_kernels', True)
         only_if_needed = kwargs.pop('only_if_needed', True)

--- a/xobjects/struct.py
+++ b/xobjects/struct.py
@@ -501,27 +501,28 @@ class Struct(metaclass=MetaStruct):
         use_prebuilt_kernels=True,
     ):
         if use_prebuilt_kernels:
-            _print_state = Print.suppress
-            Print.suppress = True
-            import xtrack as xt
-            from xtrack.prebuild_kernels import get_suitable_kernel, XT_PREBUILT_KERNELS_LOCATION
             cls = self.__class__
             context = self._context
-            # TODO: support other configs?
-            _default_config  = xt.Line().config
-            kernel_info = get_suitable_kernel(
-                _default_config, (cls,) + tuple(extra_classes)
-            )
-            Print.suppress = _print_state
-            if kernel_info and isinstance(context, ContextCpu):
-                module_name, _ = kernel_info
-                kernels = context.kernels_from_file(
-                    module_name=module_name,
-                    containing_dir=XT_PREBUILT_KERNELS_LOCATION,
-                    kernel_descriptions=self._kernels,
+            if context.allow_prebuilt_kernels:
+                import xtrack as xt
+                from xtrack.prebuild_kernels import get_suitable_kernel, XT_PREBUILT_KERNELS_LOCATION
+                # TODO: support other configs?
+                _default_config  = xt.Line().config
+                _print_state = Print.suppress
+                Print.suppress = True
+                kernel_info = get_suitable_kernel(
+                    _default_config, (cls,) + tuple(extra_classes)
                 )
-                context.kernels.update(kernels)
-                return
+                Print.suppress = _print_state
+                if kernel_info:
+                    module_name, _ = kernel_info
+                    kernels = context.kernels_from_file(
+                        module_name=module_name,
+                        containing_dir=XT_PREBUILT_KERNELS_LOCATION,
+                        kernel_descriptions=self._kernels,
+                    )
+                    context.kernels.update(kernels)
+                    return
         self.compile_class_kernels(
             context=self._context,
             only_if_needed=only_if_needed,

--- a/xobjects/struct.py
+++ b/xobjects/struct.py
@@ -518,7 +518,7 @@ class Struct(metaclass=MetaStruct):
                 kernels = context.kernels_from_file(
                     module_name=module_name,
                     containing_dir=XT_PREBUILT_KERNELS_LOCATION,
-                    kernel_descriptions=get_kernels_with_default_particles(self),
+                    kernel_descriptions=self._kernels,
                 )
                 context.kernels.update(kernels)
                 return
@@ -529,37 +529,6 @@ class Struct(metaclass=MetaStruct):
             save_source_as=save_source_as,
             extra_classes=extra_classes,
         )
-
-
-def get_kernels_with_default_particles(el):
-    # prebuilt kernels only work with xp.Particles, however, at the time
-    # of compilation a lot of kernels use xp.ParticlesBase as it is not
-    # known yet which will be use.
-    import xpart as xp
-    class_kernels = {}
-    for name, ker in el._kernels.items():
-        new_args = []
-        for arg in ker.args:
-            new_arg = Arg(atype=arg.atype,
-                             pointer=arg.pointer,
-                             name=arg.name,
-                             const=arg.const,
-                             factory=arg.factory)
-            if getattr(new_arg.atype, '_DressingClass', None) == xp.ParticlesBase:
-                new_arg.atype = xp.Particles._XoStruct
-            new_args.append(new_arg)
-        if ker.ret is None:
-            new_ret = None
-        else:
-            new_ret = xo.Arg(atype=ker.ret.atype,
-                             pointer=ker.ret.pointer,
-                             name=ker.ret.name,
-                             const=ker.ret.const,
-                             factory=ker.ret.factory)
-            if getattr(new_ret.atype, '_DressingClass', None) == xp.ParticlesBase:
-                new_ret.atype = xp.Particles._XoStruct
-        class_kernels[name] = Kernel(args=new_args, ret=new_ret, c_name=ker.c_name)
-    return class_kernels
 
 
 def is_struct(atype):

--- a/xobjects/struct.py
+++ b/xobjects/struct.py
@@ -505,7 +505,10 @@ class Struct(metaclass=MetaStruct):
             context = self._context
             if context.allow_prebuilt_kernels:
                 import xtrack as xt
-                from xtrack.prebuild_kernels import get_suitable_kernel, XT_PREBUILT_KERNELS_LOCATION
+                from xtrack.prebuild_kernels import (
+                    get_suitable_kernel,
+                    XT_PREBUILT_KERNELS_LOCATION
+                )
                 # TODO: support other configs?
                 _default_config  = xt.Line().config
                 _print_state = Print.suppress
@@ -516,10 +519,12 @@ class Struct(metaclass=MetaStruct):
                 Print.suppress = _print_state
                 if kernel_info:
                     module_name, _ = kernel_info
+                    extra_kernels = _kernels_with_particles(
+                        self._kernels)
                     kernels = context.kernels_from_file(
                         module_name=module_name,
                         containing_dir=XT_PREBUILT_KERNELS_LOCATION,
-                        kernel_descriptions=self._kernels,
+                        kernel_descriptions=extra_kernels,
                     )
                     context.kernels.update(kernels)
                     return
@@ -530,6 +535,45 @@ class Struct(metaclass=MetaStruct):
             save_source_as=save_source_as,
             extra_classes=extra_classes,
         )
+
+
+def _kernels_with_particles(kernel_descriptions):
+    # prebuilt kernels only work with xp.Particles, however, at the time of
+    # compilation a lot of kernels use xp.ParticlesBase as it is not known
+    # yet which will be used. So we fix this when reading the built kernel.
+    import xpart as xp
+    new_descriptions = {}
+    for name, ker in kernel_descriptions.items():
+        if not isinstance(ker, Kernel):
+            raise ValueError(f"Kernel {name} of type "
+                           + f"{ker.__class__.__name__} "
+                           + f"currently not supported.")
+        new_args = []
+        for arg in ker.args:
+            new_arg = Arg(atype=arg.atype,
+                          pointer=arg.pointer,
+                          name=arg.name,
+                          const=arg.const,
+                          factory=arg.factory)
+            if getattr(new_arg.atype, '_DressingClass',
+                       None) == xp.ParticlesBase:
+                new_arg.atype = xp.Particles._XoStruct
+            new_args.append(new_arg)
+        if ker.ret is None:
+            new_ret = None
+        else:
+            new_ret = Arg(atype=ker.ret.atype,
+                          pointer=ker.ret.pointer,
+                          name=ker.ret.name,
+                          const=ker.ret.const,
+                          factory=ker.ret.factory)
+            if getattr(new_ret.atype, '_DressingClass',
+                       None) == xp.ParticlesBase:
+                new_ret.atype = xp.Particles._XoStruct
+        new_descriptions[name] = Kernel(args=new_args,
+                                        ret=new_ret,
+                                        c_name=ker.c_name)
+    return new_descriptions
 
 
 def is_struct(atype):


### PR DESCRIPTION
## Description
<!-- Describe why you are making the changes you do
 and link the relevant issues below. -->

When compiling kernels at the level of the `xo.Struct`, it will first verify if prebuilt kernels are available that already provide these kernel functions. Until now this functionality only existed for `track_line` but with this PR it also works when tracking individual elements or using individual kernels. For this to work, PR https://github.com/xsuite/xtrack/pull/448 and https://github.com/xsuite/xpart/pull/104 are needed, which provide the necessary changes.

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [ ] All the tests are passing, including my new ones
- [ ] I described my changes in this PR description

Optional:

- [ ] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
