### PR TITLE
In HybridClass.to_dict() do not output fields with default values

### DIFF
--- a/tests/test_array.py
+++ b/tests/test_array.py
@@ -125,6 +125,12 @@ def test_array_allocation():
     assert ss._itemtype == xo.Int64
 
 
+def test_static_array_allocation_with_none():
+    MyArray = xo.Int64[10]
+    ss = MyArray(None)
+    assert ss._itemtype == xo.Int64
+
+
 def test_array_sshape_stype():
     Array1D = xo.Int64[3]
     Array2D = xo.Int64[2, 3]

--- a/tests/test_hybrid_class.py
+++ b/tests/test_hybrid_class.py
@@ -310,3 +310,23 @@ def test_move_field_of_nested_fails(classes_for_test_hybrid_class_ref):
 
     with pytest.raises(MemoryError):
         outer.inner.move(_buffer=different_buffer)
+
+
+def test_to_json_defaults():
+    class A(xo.HybridClass):
+        _xofields = {
+            'a': xo.Float64[3],
+            'b': xo.Int64,
+            'c': xo.Field(xo.Int32, default=42),
+            'd': xo.Field(xo.Int32, default_factory=lambda: 7),
+        }
+
+    a = A(c=42)
+    assert a.to_dict() == {'__class__': 'A'}
+
+    b = A(a=[1, 2, 3], d=8)
+    b_dict = b.to_dict()
+    assert b_dict.pop('__class__') == 'A'
+    assert np.all(b_dict.pop('a') == [1, 2, 3])
+    assert b_dict.pop('d') == 8
+    assert b_dict == {}

--- a/xobjects/array.py
+++ b/xobjects/array.py
@@ -307,10 +307,14 @@ class Array(metaclass=MetaArray):
             if len(args) == 0:
                 value = None
             elif len(args) == 1:
-                shape = get_shape_from_array(args[0], len(cls._shape))
-                if shape != cls._shape:
-                    raise ValueError(f"shape not valid for {args[0]} ")
-                value = args[0]
+                arg, = args
+                if arg is None:
+                    value = None
+                else:
+                    shape = get_shape_from_array(arg, len(cls._shape))
+                    if shape != cls._shape:
+                        raise ValueError(f"shape not valid for {arg} ")
+                    value = arg
             elif len(args) > 1:
                 raise ValueError("too many arguments")
             size = cls._size

--- a/xobjects/hybrid_class.py
+++ b/xobjects/hybrid_class.py
@@ -285,12 +285,11 @@ class HybridClass(metaclass=MetaHybridClass):
         else:
             obj = self
 
-        for ff in obj._fields:
-            if (
-                hasattr(self, "_skip_in_to_dict")
-                and ff in self._skip_in_to_dict
-            ):
-                continue
+        skip_fields = set(getattr(obj, '_skip_in_to_dict', []))
+        additional_fields = set(getattr(obj, '_store_in_to_dict', []))
+        fields_to_store = (set(obj._fields) - skip_fields) | additional_fields
+
+        for ff in fields_to_store:
             vv = getattr(obj, ff)
             if hasattr(vv, "to_dict"):
                 out[ff] = vv.to_dict()
@@ -298,16 +297,6 @@ class HybridClass(metaclass=MetaHybridClass):
                 out[ff] = vv._to_dict()
             else:
                 out[ff] = vv
-
-        if hasattr(obj, "_store_in_to_dict"):
-            for nn in obj._store_in_to_dict:
-                ww = getattr(obj, nn)
-                if hasattr(ww, "to_dict"):
-                    out[nn] = ww.to_dict()
-                elif hasattr(ww, "_to_dict"):
-                    out[nn] = ww._to_dict()
-                else:
-                    out[nn] = ww
 
         return out
 


### PR DESCRIPTION
## Description

Do not output hybrid class fields to dict if their values are the same as the default value for the field.

## Checklist

Mandatory: 

- [x] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
