### PR TITLE
Move assert_allclose to general to avoid a hard dependency on pytest

### DIFF
--- a/xobjects/__init__.py
+++ b/xobjects/__init__.py
@@ -36,6 +36,6 @@ from .linkedarray import BypassLinked
 
 from .general import _print
 
-from .test_helpers import assert_allclose
+from .general import assert_allclose
 
 from ._version import __version__

--- a/xobjects/general.py
+++ b/xobjects/general.py
@@ -1,3 +1,10 @@
+# copyright ################################# #
+# This file is part of the Xobjects Package.  #
+# Copyright (c) CERN, 2024.                   #
+# ########################################### #
+from numpy.testing import assert_allclose as np_assert_allclose
+
+
 class Print:
     suppress = False
 
@@ -7,3 +14,11 @@ class Print:
 
 
 _print = Print()
+
+
+def assert_allclose(a, b, rtol=1e-7, atol=1e-7):
+    if hasattr(a, 'get'):
+        a = a.get()
+    if hasattr(b, 'get'):
+        b = b.get()
+    np_assert_allclose(a, b, rtol=rtol, atol=atol)

--- a/xobjects/test_helpers.py
+++ b/xobjects/test_helpers.py
@@ -5,7 +5,6 @@
 
 from functools import wraps
 from typing import Callable, Iterable, Union
-from numpy.testing import assert_allclose as np_assert_allclose
 
 import pytest
 
@@ -84,10 +83,3 @@ def requires_context(context_name: str):
         return lambda test_function: test_function
 
     return pytest.mark.skip(f"{context_name} is unavailable on this platform.")
-
-def assert_allclose(a, b, rtol=1e-7, atol=1e-7):
-    if hasattr(a, 'get'):
-        a = a.get()
-    if hasattr(b, 'get'):
-        b = b.get()
-    np_assert_allclose(a, b, rtol=rtol, atol=atol)


### PR DESCRIPTION
## Description

The module `xobjects.test_helpers` has so far only been used in testing, however currently the function `assert_allclose` is imported from in in `__init__.py` making it part of the main package. The `test_helpers` module requires `pytest`, which we don't necessarily want to be a required dependency, but the current implementation effectively makes it so. This PR moves the `assert_allclose` function to `xobjects.general` instead to avoid this problem.
