### PR TITLE
Build OpenCL kernels requiring CL2.0 (needed for __generic args)

### DIFF
--- a/xobjects/context_cupy.py
+++ b/xobjects/context_cupy.py
@@ -473,6 +473,9 @@ class ContextCupy(XContext):
 
         return out_kernels
 
+    def __str__(self):
+        return f"{type(self).__name__}:{cupy.cuda.get_device_id()}"
+
     def nparray_to_context_array(self, arr):
         """
         Copies a numpy array to the device memory.

--- a/xobjects/context_pyopencl.py
+++ b/xobjects/context_pyopencl.py
@@ -218,7 +218,9 @@ class ContextPyopencl(XContext):
             with open(save_source_as, "w") as fid:
                 fid.write(specialized_source)
 
-        prg = cl.Program(self.context, specialized_source).build()
+        prg = cl.Program(self.context, specialized_source).build(
+            options="-cl-std=CL2.0"
+        )
 
         out_kernels = {}
         for pyname, kernel in kernel_descriptions.items():

--- a/xobjects/context_pyopencl.py
+++ b/xobjects/context_pyopencl.py
@@ -219,7 +219,7 @@ class ContextPyopencl(XContext):
                 fid.write(specialized_source)
 
         prg = cl.Program(self.context, specialized_source).build(
-            options="-cl-std=CL2.0"
+            options="-cl-std=CL2.0",
         )
 
         out_kernels = {}
@@ -237,6 +237,11 @@ class ContextPyopencl(XContext):
             out_kernels[pyname].specialized_source = specialized_source
 
         return out_kernels
+
+    def __str__(self):
+        platform_id = cl.get_platforms().index(self.platform)
+        device_id = self.platform.get_devices().index(self.device)
+        return f"{type(self).__name__}:{platform_id}.{device_id}"
 
     def nparray_to_context_array(self, arr):
         """


### PR DESCRIPTION
## Description

It seems that OpenCL on CUDA is quite permissive, whereas on AMD machines, which more closely follow OpenCL spec, CL1.2 is taken as the default version even if the actual device supports higher ones.

The current version of Xtrack contains code incompatible with CL1.2. This is because in some instances local scope values are passed to `__global` parameters. CL2.0 introduces a default `__generic` parameter, which accepts either, in a manner similar to CUDA. In particular the function `multipole_compute_dpx_dpy_single_particle` receives arguments from either memory. Requiring CL2.0 is the easiest fix in this case: the alternatives are to explicitly make two versions of the function, or manually copy from the global memory to local.

I am preparing a PR for Xtrack that fixes issues encountered on AMD, this is a prerequisite for those changes.

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [x] I have updated the docs in relation to my changes, if applicable
- [x] I have tested also GPU contexts
