### PR TITLE
Fix when return value of Method is None

### DIFF
--- a/xobjects/capi.py
+++ b/xobjects/capi.py
@@ -471,7 +471,7 @@ def gen_method_switch(cls, path, conf, method):
         #endif"""
         )
     lst.append("  }")
-    lst.append("  return 0;")
+    lst.append(f"  return{'' if method.ret is None else ' 0'};")
     lst.append("}")
     return "\n".join(lst), kernel
 


### PR DESCRIPTION
## Description
<!-- Describe why you are making the changes you do
 and link the relevant issues below. -->

Quick fix: when the return value of a `Method` is None, it used to still `return 0;` as a default case (which crashes the compilation).

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [ ] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
