### PR TITLE
Bugfix in c defs

### DIFF
--- a/xobjects/context_cpu.py
+++ b/xobjects/context_cpu.py
@@ -399,7 +399,7 @@ class ContextCpu(XContext):
 
         for pyname, kernel in kernel_descriptions.items():
             # check if kernel not already declared
-            if f' {kernel.c_name}(' not in cdefs:
+            if f" {kernel.c_name}(" not in cdefs:
                 signature = cdef_from_kernel(kernel, pyname)
                 ffi_interface.cdef(signature)
                 log.debug(f"cffi def {pyname} {signature}")

--- a/xobjects/context_cpu.py
+++ b/xobjects/context_cpu.py
@@ -398,7 +398,7 @@ class ContextCpu(XContext):
             _print("Compiling ContextCpu kernels...")
 
         for pyname, kernel in kernel_descriptions.items():
-            if pyname not in cdefs:  # check if kernel not already declared
+            if f' {kernel.c_name}(' not in cdefs:  # check if kernel not already declared
                 signature = cdef_from_kernel(kernel, pyname)
                 ffi_interface.cdef(signature)
                 log.debug(f"cffi def {pyname} {signature}")

--- a/xobjects/context_cpu.py
+++ b/xobjects/context_cpu.py
@@ -398,7 +398,8 @@ class ContextCpu(XContext):
             _print("Compiling ContextCpu kernels...")
 
         for pyname, kernel in kernel_descriptions.items():
-            if f' {kernel.c_name}(' not in cdefs:  # check if kernel not already declared
+            # check if kernel not already declared
+            if f' {kernel.c_name}(' not in cdefs:
                 signature = cdef_from_kernel(kernel, pyname)
                 ffi_interface.cdef(signature)
                 log.debug(f"cffi def {pyname} {signature}")


### PR DESCRIPTION
## Description
<!-- Describe why you are making the changes you do
 and link the relevant issues below. -->

Fixed a small bug in `cdefs` before compiling a CPU kernel.
The code would check if a cdef for this kernel already exists, however, it would do so by checking by the Python name instead of the name in C.

Furthermore, I added a space before and a `(` after the cname to be searched for, as otherwise if kernels exist which have the name of the new kernel as a part, the new one would not be generated.

E.g. if there already is a kernel definition `void LocalSegment_crossing_drift(double s);` then the new kernel `void crossing_drift(double s1, double s2);` would never be generated. Searching for `f" {cname}("` avoids this problem.

All `xobjects` tests pass, and all `xtrack` tests with `ContextCpu` as well (did not test the other contexts as they are not affected).

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [X] All the tests are passing, including my new ones
- [ ] I described my changes in this PR description

Optional:

- [X] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
