### PR TITLE
Mark all @for_all_test_contexts tests with tag `context_dependent`

### DIFF
--- a/xobjects/test_helpers.py
+++ b/xobjects/test_helpers.py
@@ -39,10 +39,12 @@ def _for_all_test_contexts_excluding(
             f"this test: {excluding}."
         )(actual_test)
 
-    return pytest.mark.parametrize(
+    test = pytest.mark.parametrize(
         "test_context",
         test_context_names,
     )(actual_test)
+
+    return pytest.mark.context_dependent(test)
 
 
 def for_all_test_contexts(*args, **kwargs):
@@ -80,7 +82,7 @@ def requires_context(context_name: str):
     ctx_names = (type(ctx).__name__ for ctx in get_test_contexts())
 
     if {context_name} & set(ctx_names):  # proceed as normal
-        return lambda test_function: test_function
+        return pytest.mark.context_dependent
 
     return pytest.mark.skip(f"{context_name} is unavailable on this platform.")
 


### PR DESCRIPTION
## Description

Automatically add a tag (`context_dependent`) to all the tests using `@for_all_test_contexts` and `@require_context`. This allows to select or exclude them using the tag in pytests, e.g. `pytest -m context_dependent` or `-m 'not context_dependent'`.

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
