### PR TITLE
Add context-based define flags and propagate extra compile flags

### DIFF
--- a/xobjects/context.py
+++ b/xobjects/context.py
@@ -254,6 +254,7 @@ class XContext(ABC):
         extra_classes: Sequence[Type] = (),
         extra_headers: Sequence[SourceType] = (),
         compile: bool = True,  # noqa
+        extra_compile_args: Sequence[str] = (),
     ):
         """
         Adds user-defined kernels to the context. The kernel source
@@ -333,6 +334,7 @@ class XContext(ABC):
             extra_classes=extra_classes,
             extra_headers=extra_headers,
             compile=compile,
+            extra_compile_args=extra_compile_args,
         )
         self.kernels.update(generated_kernels)
 
@@ -348,6 +350,7 @@ class XContext(ABC):
         extra_classes: Sequence[Type],
         extra_headers: Sequence[SourceType],
         compile: bool,
+        extra_compile_args: Sequence[str],
     ) -> Dict[Tuple[str, tuple], KernelType]:
         pass
 

--- a/xobjects/context_cpu.py
+++ b/xobjects/context_cpu.py
@@ -169,8 +169,8 @@ class ContextCpu(XContext):
         specialize=True,
         apply_to_source=(),
         save_source_as=None,
-        extra_compile_args: Sequence[str] = ("-O3", "-Wno-unused-function"),
-        extra_link_args: Sequence[str] = ("-O3",),
+        extra_compile_args: Sequence[str] = (),
+        extra_link_args: Sequence[str] = (),
         extra_cdef="",
         extra_classes=(),
         extra_headers=(),
@@ -271,13 +271,16 @@ class ContextCpu(XContext):
         specialize=True,
         apply_to_source=(),
         save_source_as=None,
-        extra_compile_args=("-O3", "-Wno-unused-function"),
-        extra_link_args=("-O3",),
+        extra_compile_args=(),
+        extra_link_args=(),
         extra_cdef="",
         extra_classes=(),
         extra_headers=(),
         compile=True,  # noqa
     ) -> Dict[Tuple[str, tuple], "KernelCpu"]:
+        extra_compile_args += ("-O3", "-Wno-unused-function")
+        extra_link_args += ("-O3",)
+
         # Determine names and paths
         clean_up_so = not module_name
         module_name = module_name or str(uuid.uuid4().hex)
@@ -409,20 +412,25 @@ class ContextCpu(XContext):
             ffi_interface.cdef("int omp_get_max_threads();")
 
         # Compile
-        xtr_compile_args = ["-std=c99"]
-        xtr_link_args = ["-std=c99"]
+        xtr_compile_args = ["-std=c99", "-DXO_CONTEXT_CPU"]
+        xtr_link_args = ["-std=c99", "-DXO_CONTEXT_CPU"]
         xtr_compile_args += extra_compile_args
         xtr_link_args += extra_link_args
 
         if self.openmp_enabled:
             xtr_compile_args.append("-fopenmp")
             xtr_link_args.append("-fopenmp")
+            xtr_compile_args.append("-DXO_CONTEXT_CPU_OPENMP")
+            xtr_link_args.append("-DXO_CONTEXT_CPU_OPENMP")
 
             # https://mac.r-project.org/openmp/
             # on macos comment the above and uncomment the below flags to compile OpenMP with Xcode clang:
             # xtr_compile_args.append("-Xclang")
             # xtr_compile_args.append("-fopenmp")
             # xtr_link_args.append("-lomp")
+        else:
+            xtr_compile_args.append("-DXO_CONTEXT_CPU_SERIAL")
+            xtr_link_args.append("-DXO_CONTEXT_CPU_SERIAL")
 
         if os.name == "nt":  # windows
             # TODO: to be handled properly

--- a/xobjects/context_cupy.py
+++ b/xobjects/context_cupy.py
@@ -416,6 +416,7 @@ class ContextCupy(XContext):
         specialize=True,
         apply_to_source=(),
         save_source_as=None,
+        extra_compile_args=(),
         extra_cdef=None,
         extra_classes=(),
         extra_headers=(),
@@ -454,7 +455,10 @@ class ContextCupy(XContext):
             with open(save_source_as, "w") as fid:
                 fid.write(specialized_source)
 
-        module = cupy.RawModule(code=specialized_source)
+        extra_compile_args = (*extra_compile_args, "-DXO_CONTEXT_CUDA")
+        module = cupy.RawModule(
+            code=specialized_source, options=extra_compile_args
+        )
 
         out_kernels = {}
         for pyname, kernel in kernel_descriptions.items():

--- a/xobjects/context_pyopencl.py
+++ b/xobjects/context_pyopencl.py
@@ -180,6 +180,7 @@ class ContextPyopencl(XContext):
         specialize=True,
         apply_to_source=(),
         save_source_as=None,
+        extra_compile_args=(),
         extra_cdef=None,
         extra_classes=(),
         extra_headers=(),
@@ -218,8 +219,13 @@ class ContextPyopencl(XContext):
             with open(save_source_as, "w") as fid:
                 fid.write(specialized_source)
 
+        extra_compile_args = (
+            *extra_compile_args,
+            "-cl-std=CL2.0",
+            "-DXO_CONTEXT_CL",
+        )
         prg = cl.Program(self.context, specialized_source).build(
-            options="-cl-std=CL2.0",
+            options=extra_compile_args,
         )
 
         out_kernels = {}

--- a/xobjects/hybrid_class.py
+++ b/xobjects/hybrid_class.py
@@ -96,7 +96,7 @@ class JEncoder(json.JSONEncoder):
 def _build_xofields_dict(bases, data):
     if "_xofields" in data.keys():
         xofields = data["_xofields"].copy()
-    elif any(map(lambda b: hasattr(b, "_xofields"), bases)):
+    elif any(hasattr(b, "_xofields") for b in bases):
         n_filled = 0
         for bb in bases:
             if hasattr(bb, "_xofields") and len(bb._xofields.keys()) > 0:

--- a/xobjects/struct.py
+++ b/xobjects/struct.py
@@ -473,6 +473,7 @@ class Struct(metaclass=MetaStruct):
         apply_to_source=(),
         save_source_as=None,
         extra_classes=(),
+        extra_compile_args=(),
     ):
         if only_if_needed:
             all_found = True
@@ -489,6 +490,7 @@ class Struct(metaclass=MetaStruct):
             extra_classes=[cls] + list(extra_classes),
             apply_to_source=apply_to_source,
             save_source_as=save_source_as,
+            extra_compile_args=extra_compile_args,
         )
 
     def compile_kernels(
@@ -497,6 +499,7 @@ class Struct(metaclass=MetaStruct):
         apply_to_source=(),
         save_source_as=None,
         extra_classes=(),
+        extra_compile_args=(),
     ):
         self.compile_class_kernels(
             context=self._context,
@@ -504,6 +507,7 @@ class Struct(metaclass=MetaStruct):
             apply_to_source=apply_to_source,
             save_source_as=save_source_as,
             extra_classes=extra_classes,
+            extra_compile_args=extra_compile_args,
         )
 
 


### PR DESCRIPTION
## Description

In preparation for using headers when building C tracking code:

- introduce context based defined flags: `XO_CONTEXT_CPU`, `XO_CONTEXT_CPU_SERIAL`, `XO_CONTEXT_CPU_OPENMP`, `XO_CONTEXT_CUDA`, `XO_CONTEXT_CL`.
- add `extra_compile_args` parameter to `Context.add_kernels` and propagate it correctly

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [x] I have tested also GPU contexts
