### PR TITLE
Allow dependent packages to register include paths with xobjects

### DIFF
--- a/xobjects/context_cpu.py
+++ b/xobjects/context_cpu.py
@@ -426,6 +426,11 @@ class ContextCpu(XContext):
             xtr_compile_args.append("-DXO_CONTEXT_CPU_SERIAL")
             xtr_link_args.append("-DXO_CONTEXT_CPU_SERIAL")
 
+        extra_include_paths = self.get_installed_c_source_paths()
+        include_flags = [f'-I{path}' for path in extra_include_paths]
+        xtr_compile_args.extend(include_flags)
+        xtr_link_args.extend(include_flags)
+
         if os.name == "nt":  # windows
             # TODO: to be handled properly
             xtr_compile_args = []

--- a/xobjects/context_cupy.py
+++ b/xobjects/context_cupy.py
@@ -456,6 +456,10 @@ class ContextCupy(XContext):
                 fid.write(specialized_source)
 
         extra_compile_args = (*extra_compile_args, "-DXO_CONTEXT_CUDA")
+        extra_include_paths = self.get_installed_c_source_paths()
+        include_flags = [f'-I{path}' for path in extra_include_paths]
+        xtr_compile_args.extend(include_flags)
+
         module = cupy.RawModule(
             code=specialized_source, options=extra_compile_args
         )

--- a/xobjects/context_pyopencl.py
+++ b/xobjects/context_pyopencl.py
@@ -219,8 +219,12 @@ class ContextPyopencl(XContext):
             with open(save_source_as, "w") as fid:
                 fid.write(specialized_source)
 
+        extra_include_paths = self.get_installed_c_source_paths()
+        include_flags = [f'-I{path}' for path in extra_include_paths]
+
         extra_compile_args = (
             *extra_compile_args,
+            *include_flags,
             "-cl-std=CL2.0",
             "-DXO_CONTEXT_CL",
         )


### PR DESCRIPTION
## Description

A package that uses Xobjects to build kernels can put the following in their `pyproject.toml`:

```toml
[project.entry-points.xobjects]
include = "mymodule"
```

The path to the directory containing `mymodule` will be added to the include path when compiling kernels with the `-I` option.

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [ ] All the tests are passing, including my new ones
- [ ] I described my changes in this PR description

Optional:

- [ ] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
