### PR TITLE
Enable -Oft=min on CUDA to decrease compile-time mem and time pressure

### DIFF
--- a/xobjects/context_cupy.py
+++ b/xobjects/context_cupy.py
@@ -466,6 +466,10 @@ class ContextCupy(XContext):
             *extra_compile_args,
             *include_flags,
             "-DXO_CONTEXT_CUDA",
+            # Skip heavy optimizations (e.g. involving cloning),
+            # which for us don't translate to a lot of runtime gains,
+            # but consume a lot of compile time and memory:
+            "--Ofast-compile=min",
         )
 
         module = cupy.RawModule(


### PR DESCRIPTION
## Description

This addresses the very high observed memory usage required to build kernels on GPU.

I ran some tests with different configurations, including:

- `-Ofast-compile` options
- `__noinline__` on the functions called from the mega-kernel `track_line`
- `-Xptxas -O N` options

Below are the results:

**Setup:** LHC line, 1000 particles, 10 turns
GPU: Nvidia H100 NVL 47 GB, NVRTC 12.9, CuPy 14.0.1
Host: Intel Xeon Platinum 8468, 56 GB RAM

| Config | Build time | Track time | vs baseline build | vs baseline track | Notes |
|--------|-----------|-----------|-------------------|-------------------|-------|
| Baseline | 1168 s | 1.306 s | — | — | Reference |
| `__noinline__` only | 978 s | 1.372 s | −16% | +5% | Not worth the complexity on its own |
| `--Ofast-compile=min` | 8.6 s | 1.543 s | −99.3% | +18% | **Best overall: fast build, near-baseline tracking speed** |
| `--Ofast-compile=min` + noinline | 7.0 s | 1.628 s | −99.4% | +25% | Noinline saves 1.5 s build but hurts tracking |
| `--Ofast-compile=mid` | 8.7 s | 1.659 s | −99.3% | +27% | Good tradeoff, slightly worse tracking than `min` |
| `--Ofast-compile=mid` + noinline | 7.2 s | 1.758 s | −99.4% | +35% | Same pattern as `min` + noinline |
| `--Ofast-compile=max` | 5.4 s | 23.240 s | −99.5% | +18× | Fast front-end skips all ptxas optimisation, tragic in tracking |
| `--Ofast-compile=max` + noinline | 5.5 s | 23.002 s | −99.5% | +18× | Not meaningfully different to above |
| `--Ofast-compile=max` + PTX O0 + no-expensive + noinline | 5.5 s | 22.970 s | −99.5% | +18× | Additional flags irrelevant |
| `-Xptxas -O0` (no fast front-end) | — | — | — | — | OOM (consumes more memory than baseline??) |

Adding more `__noinline__` statements to other functions in the `track_magnet` path yielded more (up to 4x) compile time speedup, but at a significant cost of tracking time. (On the other hand, very minimal noinlining can provide a tangible benefit for OpenCL, see below).

It seems that whatever the difference between `-Oft=0` and `-Oft=min`, the yielded optimisations are negligible for us at a tragic expense in tracking time (150x slower). (It seems setting `-Oft` [disables cloning](https://gh.evko.io/nvopen-tools/ptxas/config/opt-levels.html) which we presumably require a lot of: `min` does not even disable "expensive-optimizations"...)

In the meantime, I did not manage to accomplish a similar gain with OpenCL:

- On CUDA OpenCL there is a flag `-cl-nv-opt-level`, however it seems to be ignored by the compiler in the CUDA version under test. The general flag `-cl-opt-disable` is a nuclear option that produces unacceptably slow code, and is therefore a no-go. Perhaps this is not an interesting case in practice, who'd use `ContextPyopencl` on an Nvidia card in the wild?
- On AMD OpenCL (Radeon VII used for testing) the problem does not seem nearly as bad as on CUDA: memory consumption is not noteworthy, compile time _is_ suboptimal at 2 min, but still 10x less than 20 min, with tracking time ~3s in the same scenario as above.
    - I could not identify other tweaks to the compiler to speed it up similarly to `-Oft`.
    - **`__attribute__((noinline))` on the main per-element tracking functions improved the build time to _36 s_, so in this context could be explored?**
    - Tracking time discrepancy surely explained by Radeon VII vs H100.

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [ ] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [x] I have updated the docs in relation to my changes, if applicable
- [x] I have tested also GPU contexts
