### PR TITLE
Enable -Oft=min on CUDA to decrease compile-time mem and time pressure

### DIFF
--- a/xobjects/context_cupy.py
+++ b/xobjects/context_cupy.py
@@ -466,6 +466,10 @@ class ContextCupy(XContext):
             *extra_compile_args,
             *include_flags,
             "-DXO_CONTEXT_CUDA",
+            # Skip heavy optimizations (e.g. involving cloning),
+            # which for us don't translate to a lot of runtime gains,
+            # but consume a lot of compile time and memory:
+            "--Ofast-compile=min",
         )
 
         module = cupy.RawModule(


### PR DESCRIPTION
**Changes:**

- Improve compilation times on CUDA by switching off some expensive optimisations: see analysis in #171.