### PR TITLE
CUDA: enable -Ofc only when supported by the compiler

### DIFF
--- a/xobjects/context_cupy.py
+++ b/xobjects/context_cupy.py
@@ -4,6 +4,7 @@
 # ########################################### #
 
 import logging
+import warnings
 from typing import Dict, List, Tuple
 
 import numpy as np
@@ -32,6 +33,7 @@ try:
     import cupyx.scipy.special
     import cupyx.scipy.stats
     from cupyx.scipy import fftpack as cufftp
+    from cupy_backends.cuda.libs import nvrtc
 
     _enabled = True
 except ImportError:
@@ -40,6 +42,7 @@ except ImportError:
         message=("cupy is not installed. " "ContextCupy is not available!")
     )
     cufftp = cupy
+    nvrtc = None
     _enabled = False
 
 if _enabled:
@@ -466,11 +469,13 @@ class ContextCupy(XContext):
             *extra_compile_args,
             *include_flags,
             "-DXO_CONTEXT_CUDA",
-            # Skip heavy optimizations (e.g. involving cloning),
-            # which for us don't translate to a lot of runtime gains,
-            # but consume a lot of compile time and memory:
-            "--Ofast-compile=min",
         )
+
+        if nvrtc and nvrtc.getVersion() >= (12, 9):
+            # If supported, skip prohibitively heavy optimisations (e.g.
+            # involving cloning). This it at the expense of <20%
+            # runtime performance, but gain of a lot of compile time and memory.
+            extra_compile_args += ("--Ofast-compile=min",)
 
         module = cupy.RawModule(
             code=specialized_source, options=extra_compile_args


### PR DESCRIPTION
## Description

Enable #171 only on supported CUDA distributions (>=12.9).

If runaway memory consumption is observed during CUDA compilation, updating CUDA might be a solution.

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [x] I have tested also GPU contexts
