### PR TITLE
Enable prebuilding kernels on OpenMP

### DIFF
--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -4,7 +4,9 @@
 # ########################################### #
 
 import cffi
+import pytest
 import sysconfig
+from pathlib import Path
 
 import numpy as np
 

--- a/xobjects/context_cpu.py
+++ b/xobjects/context_cpu.py
@@ -768,10 +768,8 @@ class BufferNumpy(XBuffer):
         value = nplike_to_numpy(value)
         if dest_dtype != value.dtype:
             value = value.astype(dtype=dest_dtype)  # make a copy
-        src = value.view("int8")
-        self.buffer[offset : offset + src.nbytes] = value.flatten().view(
-            "int8"
-        )
+        src = value.flatten().view("int8")
+        self.buffer[offset : offset + src.nbytes] = src
 
     def to_bytearray(self, offset, nbytes):
         """copy in byte array: used in update_from_xbuffer"""

--- a/xobjects/context_cpu.py
+++ b/xobjects/context_cpu.py
@@ -150,8 +150,7 @@ class ContextCpu(XContext):
         """
         super().__init__()
         self.omp_num_threads = omp_num_threads
-        if omp_num_threads == 0:
-            self.allow_prebuilt_kernels = True
+        self.allow_prebuilt_kernels = True
 
     def __str__(self):
         if not self.openmp_enabled:
@@ -415,8 +414,18 @@ class ContextCpu(XContext):
                 log.debug(f"cffi def {pyname} {signature}")
 
         if self.openmp_enabled:
-            ffi_interface.cdef("void omp_set_num_threads(int);")
-            ffi_interface.cdef("int omp_get_max_threads();")
+            # The wrapper is needed to ensure that the omp functions are linked
+            ffi_interface.cdef("void xo_omp_set_num_threads(int);")
+            ffi_interface.cdef("int xo_omp_get_max_threads();")
+            specialized_source += """
+                void xo_omp_set_num_threads(int num_threads) {
+                    omp_set_num_threads(num_threads);
+                }
+
+                int xo_omp_get_max_threads(void) {
+                    return omp_get_max_threads();
+                }
+                """
 
         # Compile
         xtr_compile_args = ["-std=c99", "-DXO_CONTEXT_CPU"]
@@ -528,8 +537,8 @@ class ContextCpu(XContext):
         spec.loader.exec_module(module)
 
         if self.openmp_enabled:
-            self.omp_set_num_threads = module.lib.omp_set_num_threads
-            self.omp_get_max_threads = module.lib.omp_get_max_threads
+            self.omp_set_num_threads = module.lib.xo_omp_set_num_threads
+            self.omp_get_max_threads = module.lib.xo_omp_get_max_threads
 
         return module
 

--- a/xobjects/struct.py
+++ b/xobjects/struct.py
@@ -518,7 +518,6 @@ class Struct(metaclass=MetaStruct):
         extra_classes=(),
         extra_compile_args=(),
     ):
-
         if context.allow_prebuilt_kernels:
             _print_state = Print.suppress
             Print.suppress = True
@@ -532,6 +531,7 @@ class Struct(metaclass=MetaStruct):
                     config={},
                     tracker_element_classes=[],
                     classes=list(extra_classes) + [cls],
+                    context=context,
                 )
             except ImportError:
                 kernel_info = None


### PR DESCRIPTION
## Description

Changes in Xtrack related to being able to prebuild OpenMP kernels.
Also fix a small bug in `xo.Struct`.

## Checklist

Mandatory: 

- [x] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
