### PR TITLE
Add warnings on CUDA that compile or runtime performance may be affected

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -7,4 +7,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: psf/black@26.1.0
+      - uses: pre-commit/action@v3.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,8 +5,8 @@ repos:
     -   id: check-yaml
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
-  - repo: https://github.com/psf/black
-    rev: 23.10.1
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 26.3.1
     hooks:
       - id: black
-        language_version: python3 # Should be a command that runs python3.6+
+        language_version: python3

--- a/xobjects/context_cupy.py
+++ b/xobjects/context_cupy.py
@@ -29,6 +29,14 @@ from .specialize_source import specialize_source
 
 log = logging.getLogger(__name__)
 
+no_fast_compile = False
+"""Disable NVRTC fast compile tuning when building CUDA kernels.
+
+When set to ``True``, ``ContextCupy`` does not pass ``--Ofast-compile=min``
+to NVRTC. The ``XO_CUDA_NO_FAST_COMPILE`` environment variable provides the
+same behavior.
+"""
+
 try:
     import cupy
     import cupyx.scipy
@@ -357,8 +365,7 @@ if _enabled:
             return cupy.ndarray.__invert__(self._as_cupy())
 
 
-cudaheader: List[SourceType] = [
-    """\
+cudaheader: List[SourceType] = ["""\
 typedef signed int         int32_t;  //only_for_context cuda
 typedef signed short       int16_t;  //only_for_context cuda
 typedef signed char        int8_t;   //only_for_context cuda
@@ -375,8 +382,7 @@ typedef unsigned long long uint64_t;
   #define NULL nullptr
 #endif
 
-"""
-]
+"""]
 
 
 def nplike_to_cupy(arr):
@@ -387,6 +393,13 @@ class ContextCupy(XContext):
     """
     Creates a Cupy Context object, that allows performing the computations
     on nVidia GPUs.
+
+    The module-level flag ``xobjects.context_cupy.no_fast_compile`` controls
+    whether NVRTC fast compile tuning is disabled. By default it is ``False``,
+    so CUDA kernels built with NVRTC >= 12.9 use ``--Ofast-compile=min`` to
+    reduce compilation time and memory usage, at the cost of some runtime
+    performance. Set it to ``True`` to disable this option. The environment
+    variable ``XO_CUDA_NO_FAST_COMPILE`` also disables it.
 
     Args:
         default_block_size (int):  CUDA thread size that is used by default
@@ -491,16 +504,14 @@ class ContextCupy(XContext):
         if self.backend == "nvrtc":
             # NVRTC (default): add NVRTC-specific flags
             nvrtc_args = (*extra_compile_args,)
-            fast_compile = not os.environ.get("XO_CUDA_NO_FAST_COMPILE")
+            fast_compile = not (
+                no_fast_compile or os.environ.get("XO_CUDA_NO_FAST_COMPILE")
+            )
             if nvrtc and nvrtc.getVersion() >= (12, 9):
                 # If supported, skip prohibitively heavy optimisations (e.g.
                 # involving cloning). This it at the expense of <20%
                 # runtime performance, but gain of a lot of compile time and memory.
                 if fast_compile:
-                    warnings.warn(
-                        "Expensive compile optimisations are currently disabled to improve compile-time "
-                        "performance. To re-enable them, set the XO_CUDA_NO_FAST_COMPILE environment variable."
-                    )
                     nvrtc_args += ("--Ofast-compile=min",)
             elif fast_compile:
                 warnings.warn(

--- a/xobjects/context_cupy.py
+++ b/xobjects/context_cupy.py
@@ -8,6 +8,7 @@ import os
 import shutil
 import subprocess
 import tempfile
+import warnings
 from typing import Dict, List, Tuple, Literal
 
 import numpy as np
@@ -356,7 +357,8 @@ if _enabled:
             return cupy.ndarray.__invert__(self._as_cupy())
 
 
-cudaheader: List[SourceType] = ["""\
+cudaheader: List[SourceType] = [
+    """\
 typedef signed int         int32_t;  //only_for_context cuda
 typedef signed short       int16_t;  //only_for_context cuda
 typedef signed char        int8_t;   //only_for_context cuda
@@ -373,7 +375,8 @@ typedef unsigned long long uint64_t;
   #define NULL nullptr
 #endif
 
-"""]
+"""
+]
 
 
 def nplike_to_cupy(arr):
@@ -488,11 +491,22 @@ class ContextCupy(XContext):
         if self.backend == "nvrtc":
             # NVRTC (default): add NVRTC-specific flags
             nvrtc_args = (*extra_compile_args,)
+            fast_compile = not os.environ.get("XO_CUDA_NO_FAST_COMPILE")
             if nvrtc and nvrtc.getVersion() >= (12, 9):
                 # If supported, skip prohibitively heavy optimisations (e.g.
                 # involving cloning). This it at the expense of <20%
                 # runtime performance, but gain of a lot of compile time and memory.
-                nvrtc_args += ("--Ofast-compile=min",)
+                if fast_compile:
+                    warnings.warn(
+                        "Expensive compile optimisations are currently disabled to improve compile-time "
+                        "performance. To re-enable them, set the XO_CUDA_NO_FAST_COMPILE environment variable."
+                    )
+                    nvrtc_args += ("--Ofast-compile=min",)
+            elif fast_compile:
+                warnings.warn(
+                    "Detected nvrtc version < 12.9, which does not support compile-time optimisation tuning. "
+                    "Compilation time and memory usage might be high: if this is a problem, please update CUDA nvrtc."
+                )
 
             module = cupy.RawModule(
                 code=specialized_source, options=nvrtc_args

--- a/xobjects/headers/atomicadd.h
+++ b/xobjects/headers/atomicadd.h
@@ -102,7 +102,7 @@ DEF_ATOMIC_ADD(double  , f64)
 #if defined(XO_CONTEXT_CUDA)
     // CUDA compiler may not have <stdint.h>, so define the types if needed.
     #if defined(__CUDACC_RTC__) || defined(__HIPCC_RTC__)
-        // NVRTC and HIPRTC (CuPy RawModule default) can’t see <stdint.h> 
+        // NVRTC and HIPRTC (CuPy RawModule default) can’t see <stdint.h>
         // We detect via __CUDACC_RTC__ (Nvidia) or __HIPCC_RTC__ (ROCm)
         typedef signed char        int8_t;
         typedef short              int16_t;


### PR DESCRIPTION
## Description

Current behaviour of `ContextCupy` with respect to automatic disabling of expensive optimisations is a bit opaque, and can be transparently enabled when not desired, but also not enabled when expected.

This PR:
- adds an explanation about the auto-disabling of expensive optimisations when supported, and introduces the flag `XO_CUDA_NO_FAST_COMPILE` and the module-level switch `xo.context_cupy.no_fast_compile`, used to control this behaviour;
- when `XO_CUDA_NO_FAST_COMPILE` is not given, but the current NVRTC version does not support disabling the optimisations, emits a warning to the user that they may need to update CUDA/NVRTC if compile performance is a problem.

Additionally:
- this PR changes the CI lint workflow to use `pre-commit` so that the checks on CI and local match: currently this is not the case, which causes confusion.

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
